### PR TITLE
feat: Add QueryDSL configuration, split BaseEntity and BaseTimeEntity & enable JPA Auditing

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/common/ControllerExceptionAdvice.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/common/ControllerExceptionAdvice.kt
@@ -19,7 +19,7 @@ class ControllerExceptionAdvice {
     }
 
     @ExceptionHandler(DojoException::class)
-    fun handleMoitException(ex: DojoException): ResponseEntity<DojoApiResponse<Any>> {
+    fun handleDojoException(ex: DojoException): ResponseEntity<DojoApiResponse<Any>> {
         log.error { "Dojo Exception Handler $ex" }
         return errorResponse(ex.httpStatusCode, ex.toApiErrorResponse())
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,17 @@ project(":entity") {
 
         // Jasypt
         implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
+
+        // Querydsl
+        val queryDslVersion = "6.0"
+        implementation("io.github.openfeign.querydsl:querydsl-core:$queryDslVersion")
+        implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
+        annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
+        annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+        annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
+        // query 값 정렬
+        implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,10 @@ plugins {
     idea
 }
 
+val properties = project.properties
+
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.toVersion(properties["javaVersion"] as String)
 }
 
 allprojects {
@@ -45,13 +47,13 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         // logging
-        implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
+        implementation("io.github.oshai:kotlin-logging-jvm:${properties["kotlinLoggingJvmVersion"]}")
     }
 
     tasks.withType<KotlinCompile> {
         kotlinOptions {
             freeCompilerArgs += "-Xjsr305=strict"
-            jvmTarget = "21"
+            jvmTarget = properties["javaVersion"] as String
         }
     }
 
@@ -87,22 +89,21 @@ project(":entity") {
 
     dependencies {
         api("org.springframework.boot:spring-boot-starter-data-jpa")
-        api("com.mysql:mysql-connector-j:8.4.0")
-        runtimeOnly("com.h2database:h2") // todo : fade out
+        api("com.mysql:mysql-connector-j:${properties["mysqlConnectorVersion"]}")
+        runtimeOnly("com.h2database:h2:${properties["h2DatabaseVersion"]}") // todo : fade out
 
         // Jasypt
-        implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
+        implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:${properties["jasyptSpringBootStarterVersion"]}")
 
         // Querydsl
-        val queryDslVersion = "6.0"
-        implementation("io.github.openfeign.querydsl:querydsl-core:$queryDslVersion")
-        implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
-        annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
+        implementation("io.github.openfeign.querydsl:querydsl-core:${properties["queryDslVersion"]}")
+        implementation("io.github.openfeign.querydsl:querydsl-jpa:${properties["queryDslVersion"]}")
+        annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:${properties["queryDslVersion"]}:jpa")
         annotationProcessor("jakarta.annotation:jakarta.annotation-api")
         annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
         // query 값 정렬
-        implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
+        implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:${properties["p6spyVersion"]}")
     }
 }
 

--- a/entity/src/main/kotlin/com/mashup/dojo/SampleEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/SampleEntity.kt
@@ -1,5 +1,6 @@
 package com.mashup.dojo
 
+import com.mashup.dojo.base.BaseEntity
 import jakarta.persistence.Entity
 
 @Entity

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
@@ -1,0 +1,36 @@
+package com.mashup.dojo.base
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity : BaseTimeEntity() {
+
+    @CreatedBy
+    @Column(updatable = false)
+    var createdBy: String? = null
+        private set
+
+    @LastModifiedBy
+    var lastModifiedBy: String? = null
+        private set
+
+    @Column(nullable = false)
+    var deleted: Boolean = false
+        private set
+
+    // 재활성화 - soft delete
+    fun activate() {
+        this.deleted = false
+    }
+
+    // 비활성화 - soft delete
+    fun deactivate() {
+        this.deleted = true
+    }
+}

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
@@ -2,6 +2,9 @@ package com.mashup.dojo.base
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
@@ -11,6 +14,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity : BaseTimeEntity() {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0L
+    
     @CreatedBy
     @Column(updatable = false)
     var createdBy: String? = null
@@ -21,16 +29,16 @@ abstract class BaseEntity : BaseTimeEntity() {
         private set
 
     @Column(nullable = false)
-    var deleted: Boolean = false
+    var isDeleted: Boolean = false
         private set
 
     // 재활성화 - soft delete
     fun activate() {
-        this.deleted = false
+        this.isDeleted = false
     }
 
     // 비활성화 - soft delete
     fun deactivate() {
-        this.deleted = true
+        this.isDeleted = true
     }
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
@@ -2,9 +2,6 @@ package com.mashup.dojo.base
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
@@ -14,11 +11,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity : BaseTimeEntity() {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    val id: Long = 0L
-    
     @CreatedBy
     @Column(updatable = false)
     var createdBy: String? = null

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseEntity.kt
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity : BaseTimeEntity() {
-
     @CreatedBy
     @Column(updatable = false)
     var createdBy: String? = null

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -2,6 +2,9 @@ package com.mashup.dojo.base
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
@@ -12,6 +15,11 @@ import java.time.LocalDateTime
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0L
+    
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     lateinit var createdAt: LocalDateTime

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -14,17 +14,16 @@ import java.time.LocalDateTime
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     val id: Long = 0L
-    
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     lateinit var createdAt: LocalDateTime
         private set
-    
+
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     lateinit var updatedAt: LocalDateTime

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -13,10 +13,12 @@ import java.time.LocalDateTime
 abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "created_at", nullable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     lateinit var createdAt: LocalDateTime
-
+        private set
+    
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     lateinit var updatedAt: LocalDateTime
+        private set
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -1,10 +1,7 @@
-package com.mashup.dojo
+package com.mashup.dojo.base
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
@@ -13,11 +10,7 @@ import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
-abstract class BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    val id: Long = 0L
+abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)
@@ -26,7 +19,4 @@ abstract class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     lateinit var updatedAt: LocalDateTime
-
-    @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/config/BaseEntityConfig.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/config/BaseEntityConfig.kt
@@ -10,11 +10,9 @@ import java.util.UUID
 @EnableJpaAuditing
 @Configuration
 class BaseEntityConfig {
-
     @Bean
     fun auditorProvider(): AuditorAware<String> {
         return AuditorAware {
-
             /*
             val authentication: Authentication? = SecurityContextHolder.getContext().authentication
             if (authentication == null) {
@@ -29,7 +27,7 @@ class BaseEntityConfig {
             // principal이 Member 타입이 아닌 경우의 처리
             Optional.of("AnonymousNOT_TYPE")
              */
-            
+
             // 임시로 UUID 생성하여 반환
             Optional.of(UUID.randomUUID().toString())
         }

--- a/entity/src/main/kotlin/com/mashup/dojo/config/BaseEntityConfig.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/config/BaseEntityConfig.kt
@@ -1,0 +1,37 @@
+package com.mashup.dojo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import java.util.Optional
+import java.util.UUID
+
+@EnableJpaAuditing
+@Configuration
+class BaseEntityConfig {
+
+    @Bean
+    fun auditorProvider(): AuditorAware<String> {
+        return AuditorAware {
+
+            /*
+            val authentication: Authentication? = SecurityContextHolder.getContext().authentication
+            if (authentication == null) {
+                return@AuditorAware Optional.of("AnonymousNULL")
+            }
+
+            val principal: Any = authentication.principal
+            if (principal is Member) {
+                val email: String? = principal.email
+                return@AuditorAware Optional.ofNullable(email)
+            }
+            // principal이 Member 타입이 아닌 경우의 처리
+            Optional.of("AnonymousNOT_TYPE")
+             */
+            
+            // 임시로 UUID 생성하여 반환
+            Optional.of(UUID.randomUUID().toString())
+        }
+    }
+}

--- a/entity/src/main/kotlin/com/mashup/dojo/config/DojoJasyptConfig.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/config/DojoJasyptConfig.kt
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @EnableEncryptableProperties
 class DojoJasyptConfig {
-
     @Value("\${JASYPT_ENCRYPTOR_PASSWORD}")
     private lateinit var password: String
 
@@ -19,16 +18,17 @@ class DojoJasyptConfig {
     fun stringEncryptor(): StringEncryptor {
         val encryptor = PooledPBEStringEncryptor()
         val configPassword = password
-        val config = SimpleStringPBEConfig().apply {
-            this.password = configPassword
-            this.algorithm = "PBEWithMD5AndDES"
-            this.keyObtentionIterations = 1000
-            this.poolSize = 1
-            this.providerName = "SunJCE"
-            this.saltGenerator = org.jasypt.salt.RandomSaltGenerator()
-            this.ivGenerator = org.jasypt.iv.NoIvGenerator()
-            this.stringOutputType = "base64"
-        }
+        val config =
+            SimpleStringPBEConfig().apply {
+                this.password = configPassword
+                this.algorithm = "PBEWithMD5AndDES"
+                this.keyObtentionIterations = 1000
+                this.poolSize = 1
+                this.providerName = "SunJCE"
+                this.saltGenerator = org.jasypt.salt.RandomSaltGenerator()
+                this.ivGenerator = org.jasypt.iv.NoIvGenerator()
+                this.stringOutputType = "base64"
+            }
         encryptor.setConfig(config)
         return encryptor
     }

--- a/entity/src/main/kotlin/com/mashup/dojo/config/QuerydslConfig.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/config/QuerydslConfig.kt
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class QuerydslConfig {
-
     @PersistenceContext
     private lateinit var entityManager: EntityManager
 

--- a/entity/src/main/kotlin/com/mashup/dojo/config/QuerydslConfig.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/config/QuerydslConfig.kt
@@ -1,0 +1,19 @@
+package com.mashup.dojo.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+javaVersion=21
+kotlinLoggingJvmVersion=5.1.0
+queryDslVersion=6.0
+jasyptSpringBootStarterVersion=3.0.5
+mysqlConnectorVersion=8.4.0
+h2DatabaseVersion=2.1.210
+p6spyVersion=1.9.0


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- Querydsl 의존성, Spring Bean 등록하였습니다.
- BaseEntity를 BaseTimeEntity 와 BaseEntity로 나눴습니다.
    - BaseEntity는 생성자, 수정자를 의미합니다.
    - BaseTimeEntity는 생성 시간과 수정시간을 의미합니다. 
- JPA로 인해 생성자 및 수정자를 등록할 때 SecurityContextHolder에서 꺼내어 사용해야하지만, 우선 UUID로 두었습니다. 

### 스크린샷
<img width="322" alt="스크린샷 2024-06-14 00 16 29" src="https://github.com/mash-up-kr/Dojo-Spring/assets/109949924/efd357d1-372e-4104-9f38-d245f646e429">

<img width="757" alt="스크린샷 2024-06-14 00 18 40" src="https://github.com/mash-up-kr/Dojo-Spring/assets/109949924/23ecd2d2-23ea-49a0-a675-c4db03b33fa2">

### 주의사항
추후에 BaseEntityConfig의 auditorProvider 메서드를 Principle로 수정해야합니다.

질문 및 논의는 언제나 환영입니다.