### PR TITLE
feat; 모든 도메인 모델의 id를 string type으로 바꿔요

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/SampleController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/SampleController.kt
@@ -29,8 +29,8 @@ class SampleController(
         ]
     )
     fun test(
-        @PathVariable id: Long,
-    ): DojoApiResponse<Long> {
+        @PathVariable id: String,
+    ): DojoApiResponse<String> {
         return DojoApiResponse.success(sampleUseCase.getSampleId())
     }
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/ImageRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/ImageRepository.kt
@@ -2,14 +2,16 @@ package com.mashup.dojo
 
 import com.mashup.dojo.base.BaseEntity
 import jakarta.persistence.Entity
+import jakarta.persistence.Id
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ImageRepository : JpaRepository<ImageEntity, Long>
+interface ImageRepository : JpaRepository<ImageEntity, String>
 
 @Entity
 class ImageEntity(
-    val uuid: String,
+    @Id
+    val id: String,
     val url: String,
 ) : BaseEntity()

--- a/entity/src/main/kotlin/com/mashup/dojo/SampleEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/SampleEntity.kt
@@ -2,8 +2,11 @@ package com.mashup.dojo
 
 import com.mashup.dojo.base.BaseEntity
 import jakarta.persistence.Entity
+import jakarta.persistence.Id
 
 @Entity
 class SampleEntity(
+    @Id
+    val id: String,
     val name: String,
 ) : BaseEntity()

--- a/entity/src/main/kotlin/com/mashup/dojo/SampleRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/SampleRepository.kt
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface SampleRepository : JpaRepository<SampleEntity, Long>
+interface SampleRepository : JpaRepository<SampleEntity, String>

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -14,11 +14,6 @@ import java.time.LocalDateTime
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    val id: Long = 0L
-
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     lateinit var createdAt: LocalDateTime

--- a/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/base/BaseTimeEntity.kt
@@ -2,9 +2,6 @@ package com.mashup.dojo.base
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Image.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Image.kt
@@ -8,7 +8,7 @@ data class Image(
     val url: String,
 ) {
     companion object {
-        val MOCK_USER_IMAGE =
+        val MOCK_IMAGE =
             Image(
                 id = ImageId("12345678"),
                 url = "https://example.com/image/1"

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Member.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Member.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
  * (Mashup)Member
  */
 @JvmInline
-value class MemberId(val value: Long)
+value class MemberId(val value: String)
 
 data class Member(
     val id: MemberId,

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Pick.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Pick.kt
@@ -3,7 +3,7 @@ package com.mashup.dojo.domain
 import java.time.LocalDateTime
 
 @JvmInline
-value class PickId(val value: Long)
+value class PickId(val value: String)
 
 data class Pick(
     val id: PickId,

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Question.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Question.kt
@@ -3,7 +3,7 @@ package com.mashup.dojo.domain
 import java.time.LocalDateTime
 
 @JvmInline
-value class QuestionId(val value: Long)
+value class QuestionId(val value: String)
 
 data class Question(
     val id: QuestionId,

--- a/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
@@ -3,7 +3,7 @@ package com.mashup.dojo.domain
 import java.time.LocalDateTime
 
 @JvmInline
-value class QuestionSetId(val value: Long)
+value class QuestionSetId(val value: String)
 
 data class QuestionOrder(
     val questionId: QuestionId,

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Sample.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Sample.kt
@@ -3,7 +3,7 @@ package com.mashup.dojo.domain
 import java.time.LocalDateTime
 
 data class Sample(
-    val id: Long,
+    val id: String,
     val name: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,

--- a/service/src/main/kotlin/com/mashup/dojo/service/ImageService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/ImageService.kt
@@ -26,9 +26,9 @@ class DefaultImageService(
         uuid: String,
         imageUrl: String,
     ): ImageId {
-        val entity = ImageEntity(uuid = uuid, url = imageUrl)
+        val entity = ImageEntity(id = uuid, url = imageUrl)
         val saved = imageRepository.save(entity)
-        return ImageId(saved.uuid)
+        return ImageId(saved.id)
     }
 
     override fun load(imageId: ImageId): Image {

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -64,7 +64,7 @@ class DefaultQuestionService : QuestionService {
     companion object {
         val SAMPLE_QUESTION =
             Question(
-                id = QuestionId(8181818),
+                id = QuestionId("1234564"),
                 content = "세상에서 제일 멋쟁이인 사람",
                 type = QuestionType.FRIEND,
                 category = QuestionCategory.ROMANCE,
@@ -75,21 +75,21 @@ class DefaultQuestionService : QuestionService {
 
         val SAMPLE_QUESTION_SET =
             QuestionSet(
-                id = QuestionSetId(1),
+                id = QuestionSetId("1"),
                 questionIds =
                     listOf(
-                        QuestionOrder(QuestionId(1), 1),
-                        QuestionOrder(QuestionId(2), 2),
-                        QuestionOrder(QuestionId(3), 3),
-                        QuestionOrder(QuestionId(4), 4),
-                        QuestionOrder(QuestionId(5), 5),
-                        QuestionOrder(QuestionId(6), 6),
-                        QuestionOrder(QuestionId(7), 7),
-                        QuestionOrder(QuestionId(8), 8),
-                        QuestionOrder(QuestionId(9), 9),
-                        QuestionOrder(QuestionId(10), 10),
-                        QuestionOrder(QuestionId(11), 11),
-                        QuestionOrder(QuestionId(12), 12)
+                        QuestionOrder(QuestionId("1"), 1),
+                        QuestionOrder(QuestionId("2"), 2),
+                        QuestionOrder(QuestionId("3"), 3),
+                        QuestionOrder(QuestionId("4"), 4),
+                        QuestionOrder(QuestionId("5"), 5),
+                        QuestionOrder(QuestionId("6"), 6),
+                        QuestionOrder(QuestionId("7"), 7),
+                        QuestionOrder(QuestionId("8"), 8),
+                        QuestionOrder(QuestionId("9"), 9),
+                        QuestionOrder(QuestionId("10"), 10),
+                        QuestionOrder(QuestionId("11"), 11),
+                        QuestionOrder(QuestionId("12"), 12)
                     ),
                 publishedAt = LocalDateTime.now()
             )

--- a/service/src/main/kotlin/com/mashup/dojo/service/SampleService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/SampleService.kt
@@ -13,13 +13,13 @@ class SampleService(
     private val sampleRepository: SampleRepository,
 ) {
     fun getSample(): Sample {
-        val sampleEntity = sampleRepository.findByIdOrNull(0L) ?: throw DojoException.of(DojoExceptionType.NOT_EXIST)
+        val sampleEntity = sampleRepository.findByIdOrNull("123456") ?: throw DojoException.of(DojoExceptionType.NOT_EXIST)
         return sampleEntity.buildDomain()
     }
 
     private fun SampleEntity.buildDomain(): Sample {
         return Sample(
-            id = id,
+            id = "sample Id",
             name = name,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/SampleUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/SampleUseCase.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 class SampleUseCase(
     private val sampleService: SampleService,
 ) {
-    fun getSampleId(): Long {
+    fun getSampleId(): String {
         return sampleService.getSample().id
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- BaseTimeEntity 에 id 프로퍼티 제거
- 각 entity모델에 id 별도 정의
- 모든 도메인 모델 id type string type id 로 변경