### PR TITLE
add : create custom questionSet API

### DIFF
--- a/_endpoint_test/question.http
+++ b/_endpoint_test/question.http
@@ -1,0 +1,31 @@
+### Question API
+POST {{host}}/question
+Content-Type: application/json
+
+{
+    "content": "세상에서 제일 멋진 사람은?",
+    "type": "FRIEND",
+    "emojiImageId": "asdlandlsandlasn"
+}
+
+### QuestionSet API 
+POST {{host}}/question/custom-question-set
+Content-Type: application/json
+
+{
+    "questionIds": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12"
+    ],
+    "publishedAt": "2024-08-20T21:00:00"
+}

--- a/api/src/main/kotlin/com/mashup/dojo/QuestionController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/QuestionController.kt
@@ -2,10 +2,13 @@ package com.mashup.dojo
 
 import com.mashup.dojo.common.DojoApiResponse
 import com.mashup.dojo.domain.QuestionId
+import com.mashup.dojo.domain.QuestionSetId
 import com.mashup.dojo.dto.QuestionBulkCreateRequest
 import com.mashup.dojo.dto.QuestionCreateRequest
+import com.mashup.dojo.dto.QuestionSetCustomCreateRequest
 import com.mashup.dojo.usecase.QuestionUseCase
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,8 +23,14 @@ class QuestionController(
     private val questionUseCase: QuestionUseCase,
 ) {
     // todo : add auth param
-    @Operation(summary = "create Question API", description = "질문지 생성")
     @PostMapping
+    @Operation(
+        summary = "create Question API",
+        description = "질문을 생성합니다. 성공적으로 생성되면 생성된 질문의 UUID 를 반환합니다.",
+        responses = [
+            ApiResponse(responseCode = "201", description = "생성된 질문 Id")
+        ]
+    )
     fun createQuestion(
         @Valid @RequestBody request: QuestionCreateRequest,
     ): DojoApiResponse<QuestionId> {
@@ -34,8 +43,14 @@ class QuestionController(
         ).let { DojoApiResponse.success(it.id) }
     }
 
-    @Operation(summary = "bulk create Question API", description = "질문지 bulk 생성")
     @PostMapping("/bulk")
+    @Operation(
+        summary = "bulk create Question API",
+        description = "질문지 bulk 생성. 성공적으로 생성되면 생성된 질문의 UUID List를 반환합니다.",
+        responses = [
+            ApiResponse(responseCode = "201", description = "생성된 질문 Id")
+        ]
+    )
     fun bulkCreateQuestion(
         @Valid @RequestBody request: QuestionBulkCreateRequest,
     ): DojoApiResponse<List<QuestionId>> {
@@ -48,5 +63,19 @@ class QuestionController(
                 .map { it.id }
 
         return DojoApiResponse.success(questionIds)
+    }
+
+    @Operation(summary = "create custom QuestionSet API", description = "QuestionSet 자체 생성")
+    @PostMapping("/custom-question-set")
+    fun createCustomQuestionSet(
+        @Valid @RequestBody request: QuestionSetCustomCreateRequest,
+    ): DojoApiResponse<QuestionSetId> {
+        request.questionIds
+        val customQuestionSet =
+            questionUseCase.createCustomQuestionSet(
+                QuestionUseCase.CreateQuestionSetCommand(request.questionIds, request.publishedAt)
+            )
+
+        return DojoApiResponse.success(customQuestionSet.id)
     }
 }

--- a/api/src/main/kotlin/com/mashup/dojo/dto/QuestionDto.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/QuestionDto.kt
@@ -1,10 +1,13 @@
 package com.mashup.dojo.dto
 
 import com.mashup.dojo.domain.ImageId
+import com.mashup.dojo.domain.QuestionId
 import com.mashup.dojo.domain.QuestionType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
 
 @Schema(description = "질문 등록 요청")
 data class QuestionCreateRequest(
@@ -21,4 +24,13 @@ data class QuestionCreateRequest(
 data class QuestionBulkCreateRequest(
     @Schema(description = "질문 요청 list")
     val questionList: List<QuestionCreateRequest>,
+)
+
+@Schema(description = "커스텀 질문지 세트 생성 요청")
+data class QuestionSetCustomCreateRequest(
+    @Schema(description = "질문지 세트를 구성할 질문 id List")
+    @field:Size(min = 12, max = 12, message = "질문지 세트는 반드시 12개의 질문으로 구성되어야 합니다.")
+    val questionIds: List<QuestionId>,
+    @Schema(description = "질문지 세트를 발행할 시각")
+    val publishedAt: LocalDateTime,
 )

--- a/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
@@ -12,6 +12,7 @@ data class QuestionOrder(
 
 data class QuestionSet(
     val id: QuestionSetId,
+    // 1 based-order
     val questionIds: List<QuestionOrder>,
     // 질문 발행일
     val publishedAt: LocalDateTime,

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -25,6 +25,11 @@ interface QuestionService {
     fun getCurrentQuestionSet(): QuestionSet?
 
     fun createQuestionSet(excludedQuestionSet: QuestionSet?): QuestionSet
+
+    fun createQuestionSet(
+        questionIds: List<QuestionId>,
+        publishedAt: LocalDateTime,
+    ): QuestionSet
 }
 
 @Service
@@ -61,7 +66,21 @@ class DefaultQuestionService : QuestionService {
         return SAMPLE_QUESTION_SET
     }
 
+    override fun createQuestionSet(
+        questionIds: List<QuestionId>,
+        publishedAt: LocalDateTime,
+    ): QuestionSet {
+        require(questionIds.size == DEFAULT_QUESTION_SIZE) { "questions size for QuestionSet must be 12" }
+        require(publishedAt >= LocalDateTime.now()) { "publishedAt must be in the future" }
+
+        val questionOrders = questionIds.mapIndexed { idx, qId -> QuestionOrder(qId, idx + 1) }
+        // todo : getId by UUID String Generator
+        // questionSetRepository.save()
+        return SAMPLE_QUESTION_SET
+    }
+
     companion object {
+        private const val DEFAULT_QUESTION_SIZE: Int = 12
         val SAMPLE_QUESTION =
             Question(
                 id = QuestionId("1234564"),

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -2,11 +2,13 @@ package com.mashup.dojo.usecase
 
 import com.mashup.dojo.domain.ImageId
 import com.mashup.dojo.domain.Question
+import com.mashup.dojo.domain.QuestionId
 import com.mashup.dojo.domain.QuestionSet
 import com.mashup.dojo.domain.QuestionType
 import com.mashup.dojo.service.QuestionService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 interface QuestionUseCase {
     data class CreateCommand(
@@ -15,11 +17,18 @@ interface QuestionUseCase {
         val emojiImageId: ImageId,
     )
 
+    data class CreateQuestionSetCommand(
+        val questionIdList: List<QuestionId>,
+        val publishedAt: LocalDateTime,
+    )
+
     fun create(command: CreateCommand): Question
 
     fun bulkCreate(commands: List<CreateCommand>): List<Question>
 
     fun createQuestionSet(): QuestionSet
+
+    fun createCustomQuestionSet(command: CreateQuestionSetCommand): QuestionSet
 }
 
 @Component
@@ -46,5 +55,9 @@ class DefaultQuestionUseCase(
         // 직전에 발행된 QuestionSet 확인 및 후보에서 제외 (redis 조회 필요)
         val currentQuestionSet = questionService.getCurrentQuestionSet()
         return questionService.createQuestionSet(currentQuestionSet)
+    }
+
+    override fun createCustomQuestionSet(command: QuestionUseCase.CreateQuestionSetCommand): QuestionSet {
+        return questionService.createQuestionSet(command.questionIdList, command.publishedAt)
     }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- QuestionSet 를 custom 생성할 수 있도록 API 제공합니다. 
- 기존 Question API 에 대해 누락한 http 테스트 완료하였습니다. 

### 비고 (첨부자료)
<img width="790" alt="image" src="https://github.com/mash-up-kr/Dojo-Spring/assets/27190617/9d33cffd-fc54-4b7f-af69-1907eea31f4a">
