### PR TITLE
fix: 잘못된 QueryDSL 의존성으로 QClass 가 생성되지 않는 것을 수정했습니다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     kotlin("plugin.spring") version "1.9.24"
     kotlin("plugin.jpa") version "2.0.0"
 
+    kotlin("kapt") version "1.9.24"
+
     // lint
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 
@@ -36,6 +38,7 @@ subprojects {
         plugin("org.springframework.boot")
         plugin("io.spring.dependency-management")
         plugin("org.jlleitschuh.gradle.ktlint")
+        plugin("kotlin-kapt") // 추가
         plugin("idea")
     }
 
@@ -96,15 +99,36 @@ project(":entity") {
         // Jasypt
         implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:${properties["jasyptSpringBootStarterVersion"]}")
 
-        // Querydsl
-        implementation("io.github.openfeign.querydsl:querydsl-core:${properties["queryDslVersion"]}")
-        implementation("io.github.openfeign.querydsl:querydsl-jpa:${properties["queryDslVersion"]}")
-        annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:${properties["queryDslVersion"]}:jpa")
-        annotationProcessor("jakarta.annotation:jakarta.annotation-api")
-        annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+        // QueryDSL
+        implementation("com.querydsl:querydsl-jpa:${properties["queryDslVersion"]}:jakarta")
+        kapt("com.querydsl:querydsl-apt:${properties["queryDslVersion"]}:jakarta")
+        kapt("jakarta.annotation:jakarta.annotation-api")
+        kapt("jakarta.persistence:jakarta.persistence-api")
 
         // query 값 정렬
         implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:${properties["p6spyVersion"]}")
+    }
+
+    val generated = file("src/main/generated")
+
+    tasks.withType<JavaCompile> {
+        options.generatedSourceOutputDirectory.set(generated)
+    }
+
+    sourceSets {
+        main {
+            kotlin.srcDirs += generated
+        }
+    }
+
+    tasks.named("clean") {
+        doLast {
+            generated.deleteRecursively()
+        }
+    }
+
+    kapt {
+        generateStubs = true
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ subprojects {
         plugin("org.springframework.boot")
         plugin("io.spring.dependency-management")
         plugin("org.jlleitschuh.gradle.ktlint")
-        plugin("kotlin-kapt") // 추가
+        plugin("kotlin-kapt")
         plugin("idea")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 javaVersion=21
 kotlinLoggingJvmVersion=5.1.0
-queryDslVersion=6.0
 jasyptSpringBootStarterVersion=3.0.5
 mysqlConnectorVersion=8.4.0
 h2DatabaseVersion=2.1.210
 p6spyVersion=1.9.0
+queryDslVersion=5.0.0


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
QueryDSL 의존성을 수정했습니다.

`./gradlew clean build` 사용하면 QClass 가 생성됩니다.
`entity/generated/source/kapt/main/com/maship/dojo` 에 생성되며 clean 하면 사라지도록 했습니다.
### 비고 (첨부자료)
<img width="472" alt="스크린샷 2024-07-17 20 05 47" src="https://github.com/user-attachments/assets/158172b6-1094-424e-a8ce-595742565954">
