### PR TITLE
[feat] header로 들어오는 jwt token에 기반해 MemberPrincipal 객체에 접근할 수 있어요.

### DIFF
--- a/_endpoint_test/auth-tutorial.http
+++ b/_endpoint_test/auth-tutorial.http
@@ -1,0 +1,6 @@
+### (임시) 토큰 만들기
+GET {{host}}/public/generate-token/fake
+
+### principal 정보 받기
+GET {{host}}/authentication/test
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJfaWQiOiJmYWtlIiwiZXhwIjo0MzE0MTgzMTUyLCJpYXQiOjE3MjIxODMxNTJ9.Z4swd9nJ2BiizXP2zvHBqWQ_6XmxdYKKorQChJPZfws

--- a/api/src/main/kotlin/com/mashup/dojo/MemberAuthTokenTutorialController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberAuthTokenTutorialController.kt
@@ -1,0 +1,24 @@
+package com.mashup.dojo
+
+import com.mashup.dojo.config.security.JwtTokenService
+import com.mashup.dojo.config.security.MemberPrincipalContextHolder
+import com.mashup.dojo.domain.MemberId
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MemberAuthTokenTutorialController(
+    private val jwtTokenService: JwtTokenService
+) {
+    @GetMapping("/public/generate-token/{id}")
+    fun generate(@PathVariable id: String): String {
+        return jwtTokenService.createToken(MemberId(id)).toString()
+    }
+    
+    @GetMapping("/authentication/test")
+    fun test(): String {
+       val principal = MemberPrincipalContextHolder.current()
+        return principal.name
+    }
+}

--- a/api/src/main/kotlin/com/mashup/dojo/MemberAuthTokenTutorialController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberAuthTokenTutorialController.kt
@@ -9,16 +9,18 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class MemberAuthTokenTutorialController(
-    private val jwtTokenService: JwtTokenService
+    private val jwtTokenService: JwtTokenService,
 ) {
     @GetMapping("/public/generate-token/{id}")
-    fun generate(@PathVariable id: String): String {
+    fun generate(
+        @PathVariable id: String,
+    ): String {
         return jwtTokenService.createToken(MemberId(id)).toString()
     }
-    
+
     @GetMapping("/authentication/test")
     fun test(): String {
-       val principal = MemberPrincipalContextHolder.current()
+        val principal = MemberPrincipalContextHolder.current()
         return principal.name
     }
 }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
@@ -19,42 +19,45 @@ class JwtTokenService(
     private val secretKey: String,
 ) {
     // 30일
-    private val ACCESS_TOKEN_VALID_TIME = 30 * 24 * 60 * 60 * 1000L;
+    private val ACCESS_TOKEN_VALID_TIME = 30 * 24 * 60 * 60 * 1000L
     private val MEMBER_ID_CLAIM_KEY = "member_id"
-
 
     fun createToken(memberId: MemberId): MemberAuthToken {
         val now: Instant = Instant.now()
         val expiration = Date.from(now.plusSeconds(ACCESS_TOKEN_VALID_TIME))
 
-        val token = Jwts.builder()
-            .claim(MEMBER_ID_CLAIM_KEY, memberId.value)
-            .expiration(expiration)
-            .issuedAt(Date.from(now))
-            .signWith(Keys.hmacShaKeyFor(secretKey.toByteArray()), SIG.HS256)
-            .compact()
+        val token =
+            Jwts.builder()
+                .claim(MEMBER_ID_CLAIM_KEY, memberId.value)
+                .expiration(expiration)
+                .issuedAt(Date.from(now))
+                .signWith(Keys.hmacShaKeyFor(secretKey.toByteArray()), SIG.HS256)
+                .compact()
         return MemberAuthToken(token)
     }
 
     fun isExpired(token: MemberAuthToken): Boolean {
-        val payload = Jwts.parser()
-            .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
-            .build()
-            .parseSignedClaims(token.credentials)
-            .payload
+        val payload =
+            Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
+                .build()
+                .parseSignedClaims(token.credentials)
+                .payload
 
         return payload.expiration.before(Date())
     }
 
     fun getMemberId(token: MemberAuthToken): MemberId? {
-        val payload = Jwts.parser()
-            .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
-            .build()
-            .parseSignedClaims(token.credentials)
-            .payload
+        val payload =
+            Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
+                .build()
+                .parseSignedClaims(token.credentials)
+                .payload
 
-        return if (payload.containsKey(MEMBER_ID_CLAIM_KEY).not()) null
-        else {
+        return if (payload.containsKey(MEMBER_ID_CLAIM_KEY).not()) {
+            null
+        } else {
             val memberId = payload.get(MEMBER_ID_CLAIM_KEY, String::class.java)
             MemberId(memberId)
         }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
@@ -1,0 +1,62 @@
+package com.mashup.dojo.config.security
+
+import com.mashup.dojo.domain.MemberId
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwts.SIG
+import io.jsonwebtoken.security.Keys
+import java.time.Instant
+import java.util.*
+
+class MemberAuthToken(
+    val credentials: String,
+) {
+    override fun toString(): String {
+        return credentials
+    }
+}
+
+class JwtTokenService(
+    private val secretKey: String,
+) {
+    // 30일
+    private val ACCESS_TOKEN_VALID_TIME = 30 * 24 * 60 * 60 * 1000L;
+    private val MEMBER_ID_CLAIM_KEY = "member_id"
+
+
+    fun createToken(memberId: MemberId): MemberAuthToken {
+        val now: Instant = Instant.now()
+        val expiration = Date.from(now.plusSeconds(ACCESS_TOKEN_VALID_TIME))
+
+        val token = Jwts.builder()
+            .claim(MEMBER_ID_CLAIM_KEY, memberId.value)
+            .expiration(expiration)
+            .issuedAt(Date.from(now))
+            .signWith(Keys.hmacShaKeyFor(secretKey.toByteArray()), SIG.HS256)
+            .compact()
+        return MemberAuthToken(token)
+    }
+
+    fun isExpired(token: MemberAuthToken): Boolean {
+        val payload = Jwts.parser()
+            .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
+            .build()
+            .parseSignedClaims(token.credentials)
+            .payload
+
+        return payload.expiration.before(Date())
+    }
+
+    fun getMemberId(token: MemberAuthToken): MemberId? {
+        val payload = Jwts.parser()
+            .verifyWith(Keys.hmacShaKeyFor(secretKey.toByteArray()))
+            .build()
+            .parseSignedClaims(token.credentials)
+            .payload
+
+        return if (payload.containsKey(MEMBER_ID_CLAIM_KEY).not()) null
+        else {
+            val memberId = payload.get(MEMBER_ID_CLAIM_KEY, String::class.java)
+            MemberId(memberId)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
@@ -2,7 +2,6 @@ package com.mashup.dojo.config.security
 
 import com.mashup.dojo.DojoException
 import com.mashup.dojo.DojoExceptionType
-import com.mashup.dojo.domain.MemberId
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,13 +10,18 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 class MemberAuthTokenAuthenticationFilter(
     private val memberAuthTokenAuthenticationProvider: MemberAuthTokenAuthenticationProvider,
-): OncePerRequestFilter() {
-    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
         // Todo Path 분리 밖에서 할 수 있도록 변경하기
         // path가 public 으로 시작하면 패스
         val isPublicPath = request.servletPath.startsWith("/public")
-        if(isPublicPath) filterChain.doFilter(request, response)
-        else {
+        if (isPublicPath) {
+            filterChain.doFilter(request, response)
+        } else {
             val token = resolveMemberAuthToken(request) ?: throw DojoException.of(DojoExceptionType.AUTHENTICATION_FAILURE, "토큰을 찾을 수 없어요")
             val memberPrincipal = memberAuthTokenAuthenticationProvider.authenticate(token)
 
@@ -26,15 +30,13 @@ class MemberAuthTokenAuthenticationFilter(
     }
 
     private fun resolveMemberAuthToken(request: HttpServletRequest): MemberAuthToken? {
-        return kotlin.runCatching {  
+        return kotlin.runCatching {
             val token = request.getHeader(AUTHORIZATION_HEADER_NAME)
             MemberAuthToken(token)
         }.getOrNull()
     }
-    
+
     companion object {
-        private const val AUTHORIZATION_HEADER_NAME = "Authorization";
+        private const val AUTHORIZATION_HEADER_NAME = "Authorization"
     }
 }
-
-

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
@@ -1,0 +1,40 @@
+package com.mashup.dojo.config.security
+
+import com.mashup.dojo.DojoException
+import com.mashup.dojo.DojoExceptionType
+import com.mashup.dojo.domain.MemberId
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.filter.OncePerRequestFilter
+
+class MemberAuthTokenAuthenticationFilter(
+    private val memberAuthTokenAuthenticationProvider: MemberAuthTokenAuthenticationProvider,
+): OncePerRequestFilter() {
+    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+        // Todo Path 분리 밖에서 할 수 있도록 변경하기
+        // path가 public 으로 시작하면 패스
+        val isPublicPath = request.servletPath.startsWith("/public")
+        if(isPublicPath) filterChain.doFilter(request, response)
+        else {
+            val token = resolveMemberAuthToken(request) ?: throw DojoException.of(DojoExceptionType.AUTHENTICATION_FAILURE, "토큰을 찾을 수 없어요")
+            val memberPrincipal = memberAuthTokenAuthenticationProvider.authenticate(token)
+
+            filterChain.doFilter(MemberAuthenticatedHttpServletRequestWrapper(memberPrincipal, ServletWebRequest(request, response)), response)
+        }
+    }
+
+    private fun resolveMemberAuthToken(request: HttpServletRequest): MemberAuthToken? {
+        return kotlin.runCatching {  
+            val token = request.getHeader(AUTHORIZATION_HEADER_NAME)
+            MemberAuthToken(token)
+        }.getOrNull()
+    }
+    
+    companion object {
+        private const val AUTHORIZATION_HEADER_NAME = "Authorization";
+    }
+}
+
+

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationProvider.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationProvider.kt
@@ -1,0 +1,29 @@
+package com.mashup.dojo.config.security
+
+import com.mashup.dojo.DojoException
+import com.mashup.dojo.DojoExceptionType.AUTHENTICATION_FAILURE
+import com.mashup.dojo.DojoExceptionType.MEMBER_NOT_FOUND
+import com.mashup.dojo.domain.Member
+import com.mashup.dojo.domain.MemberId
+import com.mashup.dojo.service.MemberService
+import java.security.Principal
+
+class MemberAuthTokenAuthenticationProvider(
+    private val jwtTokenService: JwtTokenService,
+    private val memberService: MemberService,
+) {
+    fun authenticate(authToken: MemberAuthToken): MemberPrincipal {
+        if(jwtTokenService.isExpired(authToken)) throw DojoException.of(AUTHENTICATION_FAILURE, "토큰 기간이 만료되었어요. 다시 로그인해주세요.")
+        val memberId = jwtTokenService.getMemberId(authToken) ?: throw DojoException.of(AUTHENTICATION_FAILURE, "유효하지 않은 토큰이에요.")
+        val member = memberService.findMemberById(memberId) ?: throw DojoException.of(MEMBER_NOT_FOUND)
+        
+        return MemberPrincipal(member)
+    }
+}
+
+class MemberPrincipal(
+    private val member: Member,
+): Principal {
+    val id: MemberId = member.id
+    override fun getName(): String = "member(id:${member.id}/full-name:${member.fullName})"
+}

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationProvider.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationProvider.kt
@@ -13,17 +13,18 @@ class MemberAuthTokenAuthenticationProvider(
     private val memberService: MemberService,
 ) {
     fun authenticate(authToken: MemberAuthToken): MemberPrincipal {
-        if(jwtTokenService.isExpired(authToken)) throw DojoException.of(AUTHENTICATION_FAILURE, "토큰 기간이 만료되었어요. 다시 로그인해주세요.")
+        if (jwtTokenService.isExpired(authToken)) throw DojoException.of(AUTHENTICATION_FAILURE, "토큰 기간이 만료되었어요. 다시 로그인해주세요.")
         val memberId = jwtTokenService.getMemberId(authToken) ?: throw DojoException.of(AUTHENTICATION_FAILURE, "유효하지 않은 토큰이에요.")
         val member = memberService.findMemberById(memberId) ?: throw DojoException.of(MEMBER_NOT_FOUND)
-        
+
         return MemberPrincipal(member)
     }
 }
 
 class MemberPrincipal(
     private val member: Member,
-): Principal {
+) : Principal {
     val id: MemberId = member.id
+
     override fun getName(): String = "member(id:${member.id}/full-name:${member.fullName})"
 }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthenticatedHttpServletRequestWrapper.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthenticatedHttpServletRequestWrapper.kt
@@ -6,7 +6,7 @@ import java.security.Principal
 
 class MemberAuthenticatedHttpServletRequestWrapper(
     private val principal: MemberPrincipal,
-    private val request: ServletWebRequest
-): HttpServletRequestWrapper(request.request) {
+    private val request: ServletWebRequest,
+) : HttpServletRequestWrapper(request.request) {
     override fun getUserPrincipal(): Principal = principal
 }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthenticatedHttpServletRequestWrapper.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthenticatedHttpServletRequestWrapper.kt
@@ -1,0 +1,12 @@
+package com.mashup.dojo.config.security
+
+import jakarta.servlet.http.HttpServletRequestWrapper
+import org.springframework.web.context.request.ServletWebRequest
+import java.security.Principal
+
+class MemberAuthenticatedHttpServletRequestWrapper(
+    private val principal: MemberPrincipal,
+    private val request: ServletWebRequest
+): HttpServletRequestWrapper(request.request) {
+    override fun getUserPrincipal(): Principal = principal
+}

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberPrincipalContextHolder.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberPrincipalContextHolder.kt
@@ -7,11 +7,14 @@ import org.springframework.web.context.request.ServletRequestAttributes
 
 object MemberPrincipalContextHolder {
     fun current(): MemberPrincipal {
-        return when(val attributes = RequestContextHolder.currentRequestAttributes()) {
+        return when (val attributes = RequestContextHolder.currentRequestAttributes()) {
             is ServletRequestAttributes -> {
                 val principal = attributes.request.userPrincipal ?: throw DojoException.of(AUTHENTICATION_FAILURE, "principal 를 가지고 있지 않아요.")
-                if(principal is MemberPrincipal) principal
-                else throw DojoException.of(AUTHENTICATION_FAILURE, "유효한 principal 이 아니에요.") 
+                if (principal is MemberPrincipal) {
+                    principal
+                } else {
+                    throw DojoException.of(AUTHENTICATION_FAILURE, "유효한 principal 이 아니에요.")
+                }
             }
             else -> throw DojoException.of(AUTHENTICATION_FAILURE, "principal 를 가지고 있지 않아요.")
         }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberPrincipalContextHolder.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberPrincipalContextHolder.kt
@@ -1,0 +1,19 @@
+package com.mashup.dojo.config.security
+
+import com.mashup.dojo.DojoException
+import com.mashup.dojo.DojoExceptionType.AUTHENTICATION_FAILURE
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+object MemberPrincipalContextHolder {
+    fun current(): MemberPrincipal {
+        return when(val attributes = RequestContextHolder.currentRequestAttributes()) {
+            is ServletRequestAttributes -> {
+                val principal = attributes.request.userPrincipal ?: throw DojoException.of(AUTHENTICATION_FAILURE, "principal 를 가지고 있지 않아요.")
+                if(principal is MemberPrincipal) principal
+                else throw DojoException.of(AUTHENTICATION_FAILURE, "유효한 principal 이 아니에요.") 
+            }
+            else -> throw DojoException.of(AUTHENTICATION_FAILURE, "principal 를 가지고 있지 않아요.")
+        }
+    }
+}

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/WebSecurityConfiguration.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/WebSecurityConfiguration.kt
@@ -1,0 +1,26 @@
+package com.mashup.dojo.config.security
+
+import com.mashup.dojo.service.MemberService
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class WebSecurityConfiguration {
+
+    @Bean
+    fun jwtTokenService() = JwtTokenService("secret-secret-secret-dojo-secret")
+    
+    @Bean
+    fun tokenBasedAuthenticationFilter(
+        memberService: MemberService,
+        jwtTokenService: JwtTokenService,
+    ): FilterRegistrationBean<MemberAuthTokenAuthenticationFilter> {
+
+        val authenticationProvider = MemberAuthTokenAuthenticationProvider(jwtTokenService, memberService)
+
+        val filter = MemberAuthTokenAuthenticationFilter(authenticationProvider)
+
+        return FilterRegistrationBean(filter).apply {}
+    }
+}

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/WebSecurityConfiguration.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/WebSecurityConfiguration.kt
@@ -7,16 +7,14 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class WebSecurityConfiguration {
-
     @Bean
     fun jwtTokenService() = JwtTokenService("secret-secret-secret-dojo-secret")
-    
+
     @Bean
     fun tokenBasedAuthenticationFilter(
         memberService: MemberService,
         jwtTokenService: JwtTokenService,
     ): FilterRegistrationBean<MemberAuthTokenAuthenticationFilter> {
-
         val authenticationProvider = MemberAuthTokenAuthenticationProvider(jwtTokenService, memberService)
 
         val filter = MemberAuthTokenAuthenticationFilter(authenticationProvider)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,11 @@ project(":api") {
         api(project(":service"))
         implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
         implementation("org.springframework.boot:spring-boot-starter-web")
+
+        // for JWT based token
+        implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+        runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+        runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
     }
 }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- jwt token 발행, 검증하는 서비스 작성
- jwt token을 통해 MemberPrincipal 객체를 만드는 AuthenticationProvider 객체 작성
- 필터 통해 해당 과정 일어날 수 있게함
- 튜토리얼 api 작성
### 비고 (첨부자료)
- 해당 코드가 들어가면 /public 으로 시작하는 api 제외 모든 코드가 authorization 헤더의 token 값을 요구해요.
- 따라서 해당 코드는 로그인 기능(토큰 자유발급)이 개발되기 전 까지는 머지 하지 않아요. 리뷰를 위해 PR을 먼저 작성해요.