### PR TITLE
feat: 타인 프로필 조회 API

### DIFF
--- a/_endpoint_test/member.http
+++ b/_endpoint_test/member.http
@@ -17,3 +17,6 @@ Content-Type: application/json
 {
     "id": "df34d054-4534-4623-8996-9016162c430b"
 }
+
+### 타인 프로필 조회 API
+GET {{host}}/member/memberId=memberId

--- a/_endpoint_test/member.http
+++ b/_endpoint_test/member.http
@@ -19,4 +19,4 @@ Content-Type: application/json
 }
 
 ### 타인 프로필 조회 API
-GET {{host}}/member/memberId=memberId
+GET {{host}}/member/{{memberId}}}

--- a/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger { }
@@ -76,13 +75,13 @@ class MemberController(
         return DojoApiResponse.success(MemberLoginResponse(id, authToken.credentials))
     }
 
-    @GetMapping("/member")
+    @GetMapping("/member/{memberId}")
     @Operation(
         summary = "타인 멤버 프로필 조회 API",
         description = "멤버의 프로필을 조회하는 API."
     )
     fun getProfile(
-        @RequestParam memberId: String,
+        @PathVariable memberId: String,
     ): DojoApiResponse<MemberProfileResponse> {
         val profileResponse = memberUseCase.findMemberById(MemberId(memberId))
 

--- a/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
@@ -79,7 +79,7 @@ class MemberController(
     @GetMapping("/member")
     @Operation(
         summary = "타인 멤버 프로필 조회 API",
-        description = "멤버의 프로필을 조회하는 API.",
+        description = "멤버의 프로필을 조회하는 API."
     )
     fun getProfile(
         @RequestParam memberId: String,

--- a/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
@@ -5,6 +5,7 @@ import com.mashup.dojo.config.security.JwtTokenService
 import com.mashup.dojo.domain.MemberId
 import com.mashup.dojo.dto.MemberCreateRequest
 import com.mashup.dojo.dto.MemberLoginRequest
+import com.mashup.dojo.dto.MemberProfileResponse
 import com.mashup.dojo.dto.MemberUpdateRequest
 import com.mashup.dojo.service.MemberService
 import com.mashup.dojo.usecase.MemberUseCase
@@ -12,10 +13,12 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger { }
@@ -71,6 +74,30 @@ class MemberController(
         val member = memberService.findMemberById(id) ?: throw DojoException.of(DojoExceptionType.MEMBER_NOT_FOUND)
         val authToken = jwtTokenService.createToken(id)
         return DojoApiResponse.success(MemberLoginResponse(id, authToken.credentials))
+    }
+
+    @GetMapping("/member")
+    @Operation(
+        summary = "타인 멤버 프로필 조회 API",
+        description = "멤버의 프로필을 조회하는 API.",
+    )
+    fun getProfile(
+        @RequestParam memberId: String,
+    ): DojoApiResponse<MemberProfileResponse> {
+        val profileResponse = memberUseCase.findMemberById(MemberId(memberId))
+
+        return DojoApiResponse.success(
+            MemberProfileResponse(
+                memberId = profileResponse.memberId.value,
+                profileImageUrl = profileResponse.profileImageUrl,
+                memberName = profileResponse.memberName,
+                platform = profileResponse.platform,
+                ordinal = profileResponse.ordinal,
+                isFriend = profileResponse.isFriend,
+                pickCount = profileResponse.pickCount,
+                friendCount = profileResponse.friendCount
+            )
+        )
     }
 
     @PatchMapping("/member/{id}")

--- a/api/src/main/kotlin/com/mashup/dojo/dto/MemberProfileResponse.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/MemberProfileResponse.kt
@@ -1,0 +1,23 @@
+package com.mashup.dojo.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "프로필 응답 Response")
+data class MemberProfileResponse(
+    @Schema(description = "유저 id")
+    val memberId: String,
+    @Schema(description = "유저 프로필 이미지 url")
+    val profileImageUrl: String,
+    @Schema(description = "유저 이름")
+    val memberName: String,
+    @Schema(description = "유저 플랫폼")
+    val platform: String,
+    @Schema(description = "유저 기수")
+    val ordinal: Int,
+    @Schema(description = "현재 유저와 찾은 유저의 친구 여부")
+    val isFriend: Boolean,
+    @Schema(description = "유저가 받은 픽 개수")
+    val pickCount: Int,
+    @Schema(description = "유저의 친구 수")
+    val friendCount: Int,
+)

--- a/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
@@ -43,6 +43,11 @@ interface MemberRelationQueryRepository {
     fun findFriendsByFromId(fromId: String): List<String>
 
     fun findAccompanyByFromId(fromId: String): List<String>
+
+    fun isFriend(
+        fromId: String,
+        toId: String,
+    ): Boolean
 }
 
 class MemberRelationQueryRepositoryImpl(
@@ -66,6 +71,25 @@ class MemberRelationQueryRepositoryImpl(
 
     override fun findAccompanyByFromId(fromId: String): List<String> {
         return findByFromIdAndRelationType(fromId, RelationType.ACCOMPANY)
+    }
+
+    override fun isFriend(
+        fromId: String,
+        toId: String,
+    ): Boolean {
+        val memberRelationEntity = QMemberRelationEntity.memberRelationEntity
+
+        val findMemberRelation =
+            jpaQueryFactory
+                .selectFrom(memberRelationEntity)
+                .where(
+                    memberRelationEntity.fromId.eq(fromId),
+                    memberRelationEntity.toId.eq(toId),
+                    memberRelationEntity.relationType.eq(RelationType.FRIEND)
+                )
+                .fetchOne()
+
+        return findMemberRelation != null
     }
 
     private fun findByFromIdAndRelationType(

--- a/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
@@ -60,6 +60,8 @@ interface PickRepositoryCustom {
         questionId: String,
         memberId: String,
     ): Long
+
+    fun findPickCountByMemberId(memberId: String): Long
 }
 
 class PickRepositoryImpl(
@@ -154,6 +156,17 @@ class PickRepositoryImpl(
             .or(pickEntity.isPlatformOpen)
             .or(pickEntity.isMidInitialNameOpen)
             .or(pickEntity.isFullNameOpen)
+    }
+
+    override fun findPickCountByMemberId(memberId: String): Long {
+        val pickEntity = QPickEntity.pickEntity
+        return jpaQueryFactory
+            .select(Wildcard.count)
+            .from(pickEntity)
+            .where(
+                pickEntity.pickedId.eq(memberId)
+            )
+            .fetchOne() ?: 0
     }
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
@@ -59,6 +59,8 @@ interface PickService {
         memberId: MemberId,
     ): Int
 
+    fun findPickCountByMemberId(memberId: MemberId): Int
+
     fun getNextPickTime(): LocalDateTime
 
     fun getAnyOpenPickerCount(
@@ -270,6 +272,10 @@ class DefaultPickService(
         return pickRepository.findPickDetailCount(memberId = memberId.value, questionId = questionId.value).toInt()
     }
 
+    override fun findPickCountByMemberId(memberId: MemberId): Int {
+        return pickRepository.findPickCountByMemberId(memberId = memberId.value).toInt()
+    }
+    
     override fun getNextPickTime(): LocalDateTime {
         val currentTime = LocalDateTime.now(ZONE_ID)
         val today = currentTime.toLocalDate()

--- a/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
@@ -275,7 +275,7 @@ class DefaultPickService(
     override fun findPickCountByMemberId(memberId: MemberId): Int {
         return pickRepository.findPickCountByMemberId(memberId = memberId.value).toInt()
     }
-    
+
     override fun getNextPickTime(): LocalDateTime {
         val currentTime = LocalDateTime.now(ZONE_ID)
         val today = currentTime.toLocalDate()

--- a/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MemberRelationService {
-    fun getAllRelationShip(fromId: String): List<MemberId>
+    fun getAllRelationShip(fromId: MemberId): List<MemberId>
 
-    fun getFriendRelationIds(fromId: String): List<MemberId>
+    fun getFriendRelationIds(fromId: MemberId): List<MemberId>
 
-    fun getAccompanyRelationIds(fromId: String): List<MemberId>
+    fun getAccompanyRelationIds(fromId: MemberId): List<MemberId>
 
     fun createRelation(
         fromId: MemberId,
@@ -27,6 +27,11 @@ interface MemberRelationService {
         fromId: String,
         toId: String,
     )
+
+    fun isFriend(
+        fromId: MemberId,
+        toId: MemberId,
+    ): Boolean
 }
 
 @Service
@@ -34,16 +39,16 @@ interface MemberRelationService {
 class DefaultMemberRelationService(
     private val memberRelationRepository: MemberRelationRepository,
 ) : MemberRelationService {
-    override fun getAllRelationShip(fromId: String): List<MemberId> {
-        return memberRelationRepository.findByFromId(fromId).map { MemberId(it) }
+    override fun getAllRelationShip(fromId: MemberId): List<MemberId> {
+        return memberRelationRepository.findByFromId(fromId.value).map { MemberId(it) }
     }
 
-    override fun getFriendRelationIds(fromId: String): List<MemberId> {
-        return memberRelationRepository.findFriendsByFromId(fromId).map { MemberId(it) }
+    override fun getFriendRelationIds(fromId: MemberId): List<MemberId> {
+        return memberRelationRepository.findFriendsByFromId(fromId.value).map { MemberId(it) }
     }
 
-    override fun getAccompanyRelationIds(fromId: String): List<MemberId> {
-        return memberRelationRepository.findAccompanyByFromId(fromId).map { MemberId(it) }
+    override fun getAccompanyRelationIds(fromId: MemberId): List<MemberId> {
+        return memberRelationRepository.findAccompanyByFromId(fromId.value).map { MemberId(it) }
     }
 
     @Transactional
@@ -66,6 +71,13 @@ class DefaultMemberRelationService(
         }
         val updatedRelation = toDomain.updateToFriend()
         memberRelationRepository.save(updatedRelation.toEntity())
+    }
+
+    override fun isFriend(
+        fromId: MemberId,
+        toId: MemberId,
+    ): Boolean {
+        return memberRelationRepository.isFriend(fromId = fromId.value, toId = toId.value)
     }
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
@@ -1,7 +1,5 @@
 package com.mashup.dojo.usecase
 
-import com.mashup.dojo.DojoException
-import com.mashup.dojo.DojoExceptionType
 import com.mashup.dojo.domain.ImageId
 import com.mashup.dojo.domain.MemberGender
 import com.mashup.dojo.domain.MemberId

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
@@ -1,11 +1,16 @@
 package com.mashup.dojo.usecase
 
+import com.mashup.dojo.DojoException
+import com.mashup.dojo.DojoExceptionType
 import com.mashup.dojo.domain.ImageId
 import com.mashup.dojo.domain.MemberGender
 import com.mashup.dojo.domain.MemberId
 import com.mashup.dojo.domain.MemberPlatform
 import com.mashup.dojo.service.CoinService
+import com.mashup.dojo.service.ImageService
+import com.mashup.dojo.service.MemberRelationService
 import com.mashup.dojo.service.MemberService
+import com.mashup.dojo.service.PickService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,16 +28,32 @@ interface MemberUseCase {
         val profileImageId: ImageId?,
     )
 
+    data class ProfileResponse(
+        val memberId: MemberId,
+        val profileImageUrl: String,
+        val memberName: String,
+        val platform: String,
+        val ordinal: Int,
+        val isFriend: Boolean,
+        val pickCount: Int,
+        val friendCount: Int,
+    )
+
     fun create(command: CreateCommand): MemberId
 
     fun update(command: UpdateCommand): MemberId
+
+    fun findMemberById(targetMemberId: MemberId): ProfileResponse
 }
 
 @Component
 @Transactional(readOnly = true)
 class DefaultMemberUseCase(
     private val memberService: MemberService,
+    private val memberRelationService: MemberRelationService,
     private val coinService: CoinService,
+    private val imageService: ImageService,
+    private val pickService: PickService,
 ) : MemberUseCase {
     @Transactional
     override fun create(command: MemberUseCase.CreateCommand): MemberId {
@@ -60,5 +81,50 @@ class DefaultMemberUseCase(
                 profileImageId = command.profileImageId
             )
         )
+    }
+
+    override fun findMemberById(targetMemberId: MemberId): MemberUseCase.ProfileResponse {
+        // ToDo 현재 프로필 조회시 query 5번 호출되는데 나중에 수정할 것인지
+        // ToDo 추후에 데이터 넣은 후 주석 해제, 현재 MockData 반환
+
+        // val findMember =
+        //     memberService.findMemberById(targetMemberId)
+        //         ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "NOT EXIST PICKED MEMBER ID $targetMemberId")
+        //
+        // val profileImageId = findMember.profileImageId ?: ImageId("defaultImageUrl")
+        // val profileImageUrl = (
+        //     imageService.load(profileImageId)?.url
+        //         ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "해당하는 이미지를 찾을 수 없습니다. EmojiImageId: [$profileImageId}]")
+        // )
+        //
+        // val pickCountByMemberId = pickService.findPickCountByMemberId(findMember.id)
+        //
+        // // ToDo 실제 사용자 가져와야함
+        // val currentMemberId = "currentMemberId"
+        //
+        // val isFriend = memberRelationService.isFriend(MemberId(currentMemberId), targetMemberId)
+        // val friendCount = memberRelationService.getFriendRelationIds(targetMemberId).size
+
+        return MemberUseCase.ProfileResponse(
+            memberId = MemberId("targetMemberId"),
+            profileImageUrl = "targetMemberProfileImageUrl",
+            memberName = "김아무개",
+            platform = MemberPlatform.SPRING.name,
+            ordinal = 14,
+            isFriend = false,
+            pickCount = 0,
+            friendCount = 0
+        )
+
+        // return MemberUseCase.ProfileResponse(
+        //     memberId = findMember.id,
+        //     profileImageUrl = profileImageUrl,
+        //     memberName = findMember.fullName,
+        //     platform = findMember.platform.name,
+        //     ordinal = findMember.ordinal,
+        //     isFriend = isFriend,
+        //     pickCount = pickCountByMemberId,
+        //     friendCount = friendCount
+        // )
     }
 }

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/MemberUseCase.kt
@@ -1,5 +1,7 @@
 package com.mashup.dojo.usecase
 
+import com.mashup.dojo.DojoException
+import com.mashup.dojo.DojoExceptionType
 import com.mashup.dojo.domain.ImageId
 import com.mashup.dojo.domain.MemberGender
 import com.mashup.dojo.domain.MemberId
@@ -83,46 +85,34 @@ class DefaultMemberUseCase(
 
     override fun findMemberById(targetMemberId: MemberId): MemberUseCase.ProfileResponse {
         // ToDo 현재 프로필 조회시 query 5번 호출되는데 나중에 수정할 것인지
-        // ToDo 추후에 데이터 넣은 후 주석 해제, 현재 MockData 반환
 
-        // val findMember =
-        //     memberService.findMemberById(targetMemberId)
-        //         ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "NOT EXIST PICKED MEMBER ID $targetMemberId")
-        //
-        // val profileImageId = findMember.profileImageId ?: ImageId("defaultImageUrl")
-        // val profileImageUrl = (
-        //     imageService.load(profileImageId)?.url
-        //         ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "해당하는 이미지를 찾을 수 없습니다. EmojiImageId: [$profileImageId}]")
-        // )
-        //
-        // val pickCountByMemberId = pickService.findPickCountByMemberId(findMember.id)
-        //
-        // // ToDo 실제 사용자 가져와야함
-        // val currentMemberId = "currentMemberId"
-        //
-        // val isFriend = memberRelationService.isFriend(MemberId(currentMemberId), targetMemberId)
-        // val friendCount = memberRelationService.getFriendRelationIds(targetMemberId).size
+        val findMember =
+            memberService.findMemberById(targetMemberId)
+                ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "NOT EXIST PICKED MEMBER ID $targetMemberId")
 
-        return MemberUseCase.ProfileResponse(
-            memberId = MemberId("targetMemberId"),
-            profileImageUrl = "targetMemberProfileImageUrl",
-            memberName = "김아무개",
-            platform = MemberPlatform.SPRING.name,
-            ordinal = 14,
-            isFriend = false,
-            pickCount = 0,
-            friendCount = 0
+        val profileImageId = findMember.profileImageId ?: ImageId("defaultImageUrl")
+        val profileImageUrl = (
+            imageService.load(profileImageId)?.url
+                ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "해당하는 이미지를 찾을 수 없습니다. EmojiImageId: [$profileImageId}]")
         )
 
-        // return MemberUseCase.ProfileResponse(
-        //     memberId = findMember.id,
-        //     profileImageUrl = profileImageUrl,
-        //     memberName = findMember.fullName,
-        //     platform = findMember.platform.name,
-        //     ordinal = findMember.ordinal,
-        //     isFriend = isFriend,
-        //     pickCount = pickCountByMemberId,
-        //     friendCount = friendCount
-        // )
+        val pickCountByMemberId = pickService.findPickCountByMemberId(findMember.id)
+
+        // ToDo 실제 사용자 가져와야함
+        val currentMemberId = "currentMemberId"
+
+        val isFriend = memberRelationService.isFriend(MemberId(currentMemberId), targetMemberId)
+        val friendCount = memberRelationService.getFriendRelationIds(targetMemberId).size
+
+        return MemberUseCase.ProfileResponse(
+            memberId = findMember.id,
+            profileImageUrl = profileImageUrl,
+            memberName = findMember.fullName,
+            platform = findMember.platform.name,
+            ordinal = findMember.ordinal,
+            isFriend = isFriend,
+            pickCount = pickCountByMemberId,
+            friendCount = friendCount
+        )
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
타인의 프로필을 조회하는 API 구현했습니다.

### 비고 (첨부자료)
1. 픽 조회 API PR #75 에서 사용하던 로직을 재사용하기 위해 base를 PR #75 로 잡고 작업했습니다.
[feat: user's pick count query](https://github.com/mash-up-kr/Dojo-Spring/pull/76/commits/f348343b5144e52a34f6b3e65a68d1bbda7a5378) https://github.com/mash-up-kr/Dojo-Spring/pull/76/commits/f348343b5144e52a34f6b3e65a68d1bbda7a5378 부터 봐주시면 좋을 것 같습니다.
2. 현재 프로필 조회시 5번(타겟 멤버, 이미지, 픽 카운트, 친구 여부, 친구수 카운트) 쿼리가 발생하는데, 추후에 수정하면 좋을 것 같습니다.
팀원분들은 어떻게 해결하시는지 궁금합니다..!