### PR TITLE
feat: Create QuestionSheet

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/scheduler/Scheduler.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/scheduler/Scheduler.kt
@@ -25,7 +25,9 @@ class Scheduler(
     @Async("questionSheetSchedulerExecutor")
     fun createQuestionSheet() {
         log.info { "=== Start Create questionSheet at ${LocalDateTime.now()}. ===" }
-        questionUseCase.createQuestionSheet()
+
+        // ToDo 친구 관계 생성 후 주석 해제할 것
+        // questionUseCase.createQuestionSheet()
         log.info { "=== Done Create questionSheet at ${LocalDateTime.now()}. ===" }
     }
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
@@ -1,6 +1,7 @@
 package com.mashup.dojo
 
 import com.mashup.dojo.base.BaseTimeEntity
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -48,6 +49,16 @@ interface MemberRelationQueryRepository {
         fromId: String,
         toId: String,
     ): Boolean
+
+    fun findRandomOfFriend(
+        memberId: String,
+        limit: Long,
+    ): List<String>
+
+    fun findRandomOfAccompany(
+        memberId: String,
+        limit: Long,
+    ): List<String>
 }
 
 class MemberRelationQueryRepositoryImpl(
@@ -90,6 +101,42 @@ class MemberRelationQueryRepositoryImpl(
                 .fetchOne()
 
         return findMemberRelation != null
+    }
+
+    override fun findRandomOfFriend(
+        memberId: String,
+        limit: Long,
+    ): List<String> {
+        val memberRelation = QMemberRelationEntity.memberRelationEntity
+
+        return jpaQueryFactory
+            .select(memberRelation.toId)
+            .from(memberRelation)
+            .where(
+                memberRelation.fromId.eq(memberId),
+                memberRelation.relationType.eq(RelationType.FRIEND)
+            )
+            .orderBy(Expressions.numberTemplate(Double::class.java, "function('RAND')").asc())
+            .limit(limit)
+            .fetch()
+    }
+
+    override fun findRandomOfAccompany(
+        memberId: String,
+        limit: Long,
+    ): List<String> {
+        val memberRelation = QMemberRelationEntity.memberRelationEntity
+
+        return jpaQueryFactory
+            .select(memberRelation.toId)
+            .from(memberRelation)
+            .where(
+                memberRelation.fromId.eq(memberId),
+                memberRelation.relationType.eq(RelationType.ACCOMPANY)
+            )
+            .orderBy(Expressions.numberTemplate(Double::class.java, "function('RAND')").asc())
+            .limit(8)
+            .fetch()
     }
 
     private fun findByFromIdAndRelationType(

--- a/entity/src/main/resources/application-entity.yaml
+++ b/entity/src/main/resources/application-entity.yaml
@@ -11,6 +11,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         show_sql: true
+        default_batch_fetch_size: 1000
 
 jasypt:
   encryptor:

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Question.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Question.kt
@@ -66,4 +66,21 @@ data class QuestionSheet(
     val questionId: QuestionId,
     val resolverId: MemberId,
     val candidates: List<MemberId>,
-)
+) {
+    companion object {
+        fun create(
+            questionSetId: QuestionSetId,
+            questionId: QuestionId,
+            resolverId: MemberId,
+            candidates: List<MemberId>,
+        ): QuestionSheet {
+            return QuestionSheet(
+                questionSheetId = QuestionSheetId(UUIDGenerator.generate()),
+                questionSetId = questionSetId,
+                questionId = questionId,
+                resolverId = resolverId,
+                candidates = candidates
+            )
+        }
+    }
+}

--- a/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
@@ -32,6 +32,10 @@ interface MemberRelationService {
         fromId: MemberId,
         toId: MemberId,
     ): Boolean
+
+    fun findCandidateOfFriend(memberId: MemberId): List<MemberId>
+
+    fun findCandidateOfAccompany(memberId: MemberId): List<MemberId>
 }
 
 @Service
@@ -78,6 +82,28 @@ class DefaultMemberRelationService(
         toId: MemberId,
     ): Boolean {
         return memberRelationRepository.isFriend(fromId = fromId.value, toId = toId.value)
+    }
+
+    override fun findCandidateOfFriend(memberId: MemberId): List<MemberId> {
+        return memberRelationRepository.findRandomOfFriend(
+            memberId = memberId.value,
+            limit = DEFAULT_CANDIDATE_SIZE
+        ).map {
+            MemberId(it)
+        }
+    }
+
+    override fun findCandidateOfAccompany(memberId: MemberId): List<MemberId> {
+        return memberRelationRepository.findRandomOfAccompany(
+            memberId = memberId.value,
+            limit = DEFAULT_CANDIDATE_SIZE
+        ).map {
+            MemberId(it)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_CANDIDATE_SIZE: Long = 8
     }
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
@@ -8,6 +8,7 @@ import com.mashup.dojo.domain.MemberId
 import com.mashup.dojo.domain.MemberRelation
 import com.mashup.dojo.domain.MemberRelationId
 import com.mashup.dojo.domain.RelationType
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -42,6 +43,8 @@ interface MemberRelationService {
 @Transactional(readOnly = true)
 class DefaultMemberRelationService(
     private val memberRelationRepository: MemberRelationRepository,
+    @Value("\${dojo.candidate.size}")
+    private val defaultCandidateSize: Long,
 ) : MemberRelationService {
     override fun getAllRelationShip(fromId: MemberId): List<MemberId> {
         return memberRelationRepository.findByFromId(fromId.value).map { MemberId(it) }
@@ -87,7 +90,7 @@ class DefaultMemberRelationService(
     override fun findCandidateOfFriend(memberId: MemberId): List<MemberId> {
         return memberRelationRepository.findRandomOfFriend(
             memberId = memberId.value,
-            limit = DEFAULT_CANDIDATE_SIZE
+            limit = defaultCandidateSize
         ).map {
             MemberId(it)
         }
@@ -96,14 +99,10 @@ class DefaultMemberRelationService(
     override fun findCandidateOfAccompany(memberId: MemberId): List<MemberId> {
         return memberRelationRepository.findRandomOfAccompany(
             memberId = memberId.value,
-            limit = DEFAULT_CANDIDATE_SIZE
+            limit = defaultCandidateSize
         ).map {
             MemberId(it)
         }
-    }
-
-    companion object {
-        private const val DEFAULT_CANDIDATE_SIZE: Long = 8
     }
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -250,33 +250,33 @@ class DefaultQuestionService(
         val friendQuestionIds = questionRepository.findFriendQuestionsByIds(questionIds)
         val accompanyQuestionIds = questionRepository.findAccompanyQuestionsByIds(questionIds)
 
-        val friendQuestionSheetEntities =
+        val friendQuestionSheets =
             friendQuestionIds.map { friendQuestionId ->
                 QuestionSheet.create(
                     questionSetId = questionSet.id,
                     questionId = QuestionId(friendQuestionId),
                     resolverId = resolver,
                     candidates = candidatesOfFriend
-                ).toEntity()
+                )
             }
 
-        val accompanyQuestionSheetEntities =
+        val accompanyQuestionSheets =
             accompanyQuestionIds.map { friendQuestionId ->
                 QuestionSheet.create(
                     questionSetId = questionSet.id,
                     questionId = QuestionId(friendQuestionId),
                     resolverId = resolver,
                     candidates = candidatesOfAccompany
-                ).toEntity()
+                )
             }
 
-        val questionSheetEntities = friendQuestionSheetEntities + accompanyQuestionSheetEntities
-        return questionSheetEntities.map { it.toQuestionSheetWithCandidatesId() }
+        return friendQuestionSheets + accompanyQuestionSheets
     }
 
     override fun saveQuestionSheets(allMemberQuestionSheets: List<QuestionSheet>): List<QuestionSheet> {
-        val questionSheetEntities = questionSheetRepository.saveAll(allMemberQuestionSheets.map { it.toEntity() })
-        return questionSheetEntities.map { it.toQuestionSheetWithCandidatesId() }
+        val questionSheetEntities = allMemberQuestionSheets.map { it.toEntity() }
+        val saveQuestionSheetEntities = questionSheetRepository.saveAll(questionSheetEntities)
+        return saveQuestionSheetEntities.map { it.toQuestionSheetWithCandidatesId() }
     }
 
     override fun getQuestionById(id: QuestionId): Question? {

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -163,8 +163,8 @@ class DefaultQuestionService(
         if (questionList.size != questionSetSize) {
             log.error {
                 "QSet 을 만들기 위한 남은 Question 들이 부족합니다. " +
-                        "조회한 QuestionSize : ${questionList.size}, 친구용 질문 size : $friendQuestionSize, 전체용 질문 size : ${accompanyQuestions.size}, " +
-                        "이전 QSetId : ${excludedQuestionSet?.id}, 제외한 QuestionIds : $excludedQuestionIds"
+                    "조회한 QuestionSize : ${questionList.size}, 친구용 질문 size : $friendQuestionSize, 전체용 질문 size : ${accompanyQuestions.size}, " +
+                    "이전 QSetId : ${excludedQuestionSet?.id}, 제외한 QuestionIds : $excludedQuestionIds"
             }
 
             throw DojoException.of(DojoExceptionType.QUESTION_LACK_FOR_CREATE_QUESTION_SET)
@@ -299,20 +299,20 @@ class DefaultQuestionService(
             QuestionSet(
                 id = QuestionSetId("1"),
                 questionIds =
-                listOf(
-                    QuestionOrder(QuestionId("1"), 1),
-                    QuestionOrder(QuestionId("2"), 2),
-                    QuestionOrder(QuestionId("3"), 3),
-                    QuestionOrder(QuestionId("4"), 4),
-                    QuestionOrder(QuestionId("5"), 5),
-                    QuestionOrder(QuestionId("6"), 6),
-                    QuestionOrder(QuestionId("7"), 7),
-                    QuestionOrder(QuestionId("8"), 8),
-                    QuestionOrder(QuestionId("9"), 9),
-                    QuestionOrder(QuestionId("10"), 10),
-                    QuestionOrder(QuestionId("11"), 11),
-                    QuestionOrder(QuestionId("12"), 12)
-                ),
+                    listOf(
+                        QuestionOrder(QuestionId("1"), 1),
+                        QuestionOrder(QuestionId("2"), 2),
+                        QuestionOrder(QuestionId("3"), 3),
+                        QuestionOrder(QuestionId("4"), 4),
+                        QuestionOrder(QuestionId("5"), 5),
+                        QuestionOrder(QuestionId("6"), 6),
+                        QuestionOrder(QuestionId("7"), 7),
+                        QuestionOrder(QuestionId("8"), 8),
+                        QuestionOrder(QuestionId("9"), 9),
+                        QuestionOrder(QuestionId("10"), 10),
+                        QuestionOrder(QuestionId("11"), 11),
+                        QuestionOrder(QuestionId("12"), 12)
+                    ),
                 publishedAt = LocalDateTime.now(),
                 endAt = LocalDateTime.now().plusHours(12)
             )
@@ -324,12 +324,12 @@ class DefaultQuestionService(
                 questionId = QuestionId("1"),
                 resolverId = MemberId("1"),
                 candidates =
-                listOf(
-                    MemberId("2"),
-                    MemberId("3"),
-                    MemberId("4"),
-                    MemberId("5")
-                )
+                    listOf(
+                        MemberId("2"),
+                        MemberId("3"),
+                        MemberId("4"),
+                        MemberId("5")
+                    )
             )
 
         // TODO: Set to 3 sheets initially. Need to modify for all users later.
@@ -343,22 +343,22 @@ private fun Question.toEntity(): QuestionEntity {
         id = id.value,
         content = content,
         type =
-        when (type) {
-            QuestionType.FRIEND -> com.mashup.dojo.QuestionType.FRIEND
-            QuestionType.ACCOMPANY -> com.mashup.dojo.QuestionType.ACCOMPANY
-        },
+            when (type) {
+                QuestionType.FRIEND -> com.mashup.dojo.QuestionType.FRIEND
+                QuestionType.ACCOMPANY -> com.mashup.dojo.QuestionType.ACCOMPANY
+            },
         category =
-        when (category) {
-            QuestionCategory.DATING -> com.mashup.dojo.QuestionCategory.DATING
-            QuestionCategory.FRIENDSHIP -> com.mashup.dojo.QuestionCategory.FRIENDSHIP
-            QuestionCategory.PERSONALITY -> com.mashup.dojo.QuestionCategory.PERSONALITY
-            QuestionCategory.ENTERTAINMENT -> com.mashup.dojo.QuestionCategory.ENTERTAINMENT
-            QuestionCategory.FITNESS -> com.mashup.dojo.QuestionCategory.FITNESS
-            QuestionCategory.APPEARANCE -> com.mashup.dojo.QuestionCategory.APPEARANCE
-            QuestionCategory.WORK -> com.mashup.dojo.QuestionCategory.WORK
-            QuestionCategory.HUMOR -> com.mashup.dojo.QuestionCategory.HUMOR
-            QuestionCategory.OTHER -> com.mashup.dojo.QuestionCategory.OTHER
-        },
+            when (category) {
+                QuestionCategory.DATING -> com.mashup.dojo.QuestionCategory.DATING
+                QuestionCategory.FRIENDSHIP -> com.mashup.dojo.QuestionCategory.FRIENDSHIP
+                QuestionCategory.PERSONALITY -> com.mashup.dojo.QuestionCategory.PERSONALITY
+                QuestionCategory.ENTERTAINMENT -> com.mashup.dojo.QuestionCategory.ENTERTAINMENT
+                QuestionCategory.FITNESS -> com.mashup.dojo.QuestionCategory.FITNESS
+                QuestionCategory.APPEARANCE -> com.mashup.dojo.QuestionCategory.APPEARANCE
+                QuestionCategory.WORK -> com.mashup.dojo.QuestionCategory.WORK
+                QuestionCategory.HUMOR -> com.mashup.dojo.QuestionCategory.HUMOR
+                QuestionCategory.OTHER -> com.mashup.dojo.QuestionCategory.OTHER
+            },
         emojiImageId = emojiImageId.value
     )
 }
@@ -368,22 +368,22 @@ private fun QuestionEntity.toQuestion(): Question {
         id = QuestionId(id),
         content = content,
         type =
-        when (type) {
-            com.mashup.dojo.QuestionType.FRIEND -> QuestionType.FRIEND
-            com.mashup.dojo.QuestionType.ACCOMPANY -> QuestionType.ACCOMPANY
-        },
+            when (type) {
+                com.mashup.dojo.QuestionType.FRIEND -> QuestionType.FRIEND
+                com.mashup.dojo.QuestionType.ACCOMPANY -> QuestionType.ACCOMPANY
+            },
         category =
-        when (category) {
-            com.mashup.dojo.QuestionCategory.DATING -> QuestionCategory.DATING
-            com.mashup.dojo.QuestionCategory.FRIENDSHIP -> QuestionCategory.FRIENDSHIP
-            com.mashup.dojo.QuestionCategory.PERSONALITY -> QuestionCategory.PERSONALITY
-            com.mashup.dojo.QuestionCategory.ENTERTAINMENT -> QuestionCategory.ENTERTAINMENT
-            com.mashup.dojo.QuestionCategory.FITNESS -> QuestionCategory.FITNESS
-            com.mashup.dojo.QuestionCategory.APPEARANCE -> QuestionCategory.APPEARANCE
-            com.mashup.dojo.QuestionCategory.WORK -> QuestionCategory.WORK
-            com.mashup.dojo.QuestionCategory.HUMOR -> QuestionCategory.HUMOR
-            com.mashup.dojo.QuestionCategory.OTHER -> QuestionCategory.OTHER
-        },
+            when (category) {
+                com.mashup.dojo.QuestionCategory.DATING -> QuestionCategory.DATING
+                com.mashup.dojo.QuestionCategory.FRIENDSHIP -> QuestionCategory.FRIENDSHIP
+                com.mashup.dojo.QuestionCategory.PERSONALITY -> QuestionCategory.PERSONALITY
+                com.mashup.dojo.QuestionCategory.ENTERTAINMENT -> QuestionCategory.ENTERTAINMENT
+                com.mashup.dojo.QuestionCategory.FITNESS -> QuestionCategory.FITNESS
+                com.mashup.dojo.QuestionCategory.APPEARANCE -> QuestionCategory.APPEARANCE
+                com.mashup.dojo.QuestionCategory.WORK -> QuestionCategory.WORK
+                com.mashup.dojo.QuestionCategory.HUMOR -> QuestionCategory.HUMOR
+                com.mashup.dojo.QuestionCategory.OTHER -> QuestionCategory.OTHER
+            },
         emojiImageId = ImageId(emojiImageId)
     )
 }

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -76,6 +76,8 @@ interface QuestionService {
         candidatesOfAccompany: List<MemberId>,
         resolver: MemberId,
     ): List<QuestionSheet>
+
+    fun saveQuestionSheets(allMemberQuestionSheets: List<QuestionSheet>): List<QuestionSheet>
 }
 
 @Service
@@ -161,8 +163,8 @@ class DefaultQuestionService(
         if (questionList.size != questionSetSize) {
             log.error {
                 "QSet 을 만들기 위한 남은 Question 들이 부족합니다. " +
-                    "조회한 QuestionSize : ${questionList.size}, 친구용 질문 size : $friendQuestionSize, 전체용 질문 size : ${accompanyQuestions.size}, " +
-                    "이전 QSetId : ${excludedQuestionSet?.id}, 제외한 QuestionIds : $excludedQuestionIds"
+                        "조회한 QuestionSize : ${questionList.size}, 친구용 질문 size : $friendQuestionSize, 전체용 질문 size : ${accompanyQuestions.size}, " +
+                        "이전 QSetId : ${excludedQuestionSet?.id}, 제외한 QuestionIds : $excludedQuestionIds"
             }
 
             throw DojoException.of(DojoExceptionType.QUESTION_LACK_FOR_CREATE_QUESTION_SET)
@@ -269,7 +271,12 @@ class DefaultQuestionService(
             }
 
         val questionSheetEntities = friendQuestionSheetEntities + accompanyQuestionSheetEntities
-        return questionSheetRepository.saveAll(questionSheetEntities).map { it.toQuestionSheetWithCandidatesId() }
+        return questionSheetEntities.map { it.toQuestionSheetWithCandidatesId() }
+    }
+
+    override fun saveQuestionSheets(allMemberQuestionSheets: List<QuestionSheet>): List<QuestionSheet> {
+        val questionSheetEntities = questionSheetRepository.saveAll(allMemberQuestionSheets.map { it.toEntity() })
+        return questionSheetEntities.map { it.toQuestionSheetWithCandidatesId() }
     }
 
     override fun getQuestionById(id: QuestionId): Question? {
@@ -292,20 +299,20 @@ class DefaultQuestionService(
             QuestionSet(
                 id = QuestionSetId("1"),
                 questionIds =
-                    listOf(
-                        QuestionOrder(QuestionId("1"), 1),
-                        QuestionOrder(QuestionId("2"), 2),
-                        QuestionOrder(QuestionId("3"), 3),
-                        QuestionOrder(QuestionId("4"), 4),
-                        QuestionOrder(QuestionId("5"), 5),
-                        QuestionOrder(QuestionId("6"), 6),
-                        QuestionOrder(QuestionId("7"), 7),
-                        QuestionOrder(QuestionId("8"), 8),
-                        QuestionOrder(QuestionId("9"), 9),
-                        QuestionOrder(QuestionId("10"), 10),
-                        QuestionOrder(QuestionId("11"), 11),
-                        QuestionOrder(QuestionId("12"), 12)
-                    ),
+                listOf(
+                    QuestionOrder(QuestionId("1"), 1),
+                    QuestionOrder(QuestionId("2"), 2),
+                    QuestionOrder(QuestionId("3"), 3),
+                    QuestionOrder(QuestionId("4"), 4),
+                    QuestionOrder(QuestionId("5"), 5),
+                    QuestionOrder(QuestionId("6"), 6),
+                    QuestionOrder(QuestionId("7"), 7),
+                    QuestionOrder(QuestionId("8"), 8),
+                    QuestionOrder(QuestionId("9"), 9),
+                    QuestionOrder(QuestionId("10"), 10),
+                    QuestionOrder(QuestionId("11"), 11),
+                    QuestionOrder(QuestionId("12"), 12)
+                ),
                 publishedAt = LocalDateTime.now(),
                 endAt = LocalDateTime.now().plusHours(12)
             )
@@ -317,12 +324,12 @@ class DefaultQuestionService(
                 questionId = QuestionId("1"),
                 resolverId = MemberId("1"),
                 candidates =
-                    listOf(
-                        MemberId("2"),
-                        MemberId("3"),
-                        MemberId("4"),
-                        MemberId("5")
-                    )
+                listOf(
+                    MemberId("2"),
+                    MemberId("3"),
+                    MemberId("4"),
+                    MemberId("5")
+                )
             )
 
         // TODO: Set to 3 sheets initially. Need to modify for all users later.
@@ -336,22 +343,22 @@ private fun Question.toEntity(): QuestionEntity {
         id = id.value,
         content = content,
         type =
-            when (type) {
-                QuestionType.FRIEND -> com.mashup.dojo.QuestionType.FRIEND
-                QuestionType.ACCOMPANY -> com.mashup.dojo.QuestionType.ACCOMPANY
-            },
+        when (type) {
+            QuestionType.FRIEND -> com.mashup.dojo.QuestionType.FRIEND
+            QuestionType.ACCOMPANY -> com.mashup.dojo.QuestionType.ACCOMPANY
+        },
         category =
-            when (category) {
-                QuestionCategory.DATING -> com.mashup.dojo.QuestionCategory.DATING
-                QuestionCategory.FRIENDSHIP -> com.mashup.dojo.QuestionCategory.FRIENDSHIP
-                QuestionCategory.PERSONALITY -> com.mashup.dojo.QuestionCategory.PERSONALITY
-                QuestionCategory.ENTERTAINMENT -> com.mashup.dojo.QuestionCategory.ENTERTAINMENT
-                QuestionCategory.FITNESS -> com.mashup.dojo.QuestionCategory.FITNESS
-                QuestionCategory.APPEARANCE -> com.mashup.dojo.QuestionCategory.APPEARANCE
-                QuestionCategory.WORK -> com.mashup.dojo.QuestionCategory.WORK
-                QuestionCategory.HUMOR -> com.mashup.dojo.QuestionCategory.HUMOR
-                QuestionCategory.OTHER -> com.mashup.dojo.QuestionCategory.OTHER
-            },
+        when (category) {
+            QuestionCategory.DATING -> com.mashup.dojo.QuestionCategory.DATING
+            QuestionCategory.FRIENDSHIP -> com.mashup.dojo.QuestionCategory.FRIENDSHIP
+            QuestionCategory.PERSONALITY -> com.mashup.dojo.QuestionCategory.PERSONALITY
+            QuestionCategory.ENTERTAINMENT -> com.mashup.dojo.QuestionCategory.ENTERTAINMENT
+            QuestionCategory.FITNESS -> com.mashup.dojo.QuestionCategory.FITNESS
+            QuestionCategory.APPEARANCE -> com.mashup.dojo.QuestionCategory.APPEARANCE
+            QuestionCategory.WORK -> com.mashup.dojo.QuestionCategory.WORK
+            QuestionCategory.HUMOR -> com.mashup.dojo.QuestionCategory.HUMOR
+            QuestionCategory.OTHER -> com.mashup.dojo.QuestionCategory.OTHER
+        },
         emojiImageId = emojiImageId.value
     )
 }
@@ -361,22 +368,22 @@ private fun QuestionEntity.toQuestion(): Question {
         id = QuestionId(id),
         content = content,
         type =
-            when (type) {
-                com.mashup.dojo.QuestionType.FRIEND -> QuestionType.FRIEND
-                com.mashup.dojo.QuestionType.ACCOMPANY -> QuestionType.ACCOMPANY
-            },
+        when (type) {
+            com.mashup.dojo.QuestionType.FRIEND -> QuestionType.FRIEND
+            com.mashup.dojo.QuestionType.ACCOMPANY -> QuestionType.ACCOMPANY
+        },
         category =
-            when (category) {
-                com.mashup.dojo.QuestionCategory.DATING -> QuestionCategory.DATING
-                com.mashup.dojo.QuestionCategory.FRIENDSHIP -> QuestionCategory.FRIENDSHIP
-                com.mashup.dojo.QuestionCategory.PERSONALITY -> QuestionCategory.PERSONALITY
-                com.mashup.dojo.QuestionCategory.ENTERTAINMENT -> QuestionCategory.ENTERTAINMENT
-                com.mashup.dojo.QuestionCategory.FITNESS -> QuestionCategory.FITNESS
-                com.mashup.dojo.QuestionCategory.APPEARANCE -> QuestionCategory.APPEARANCE
-                com.mashup.dojo.QuestionCategory.WORK -> QuestionCategory.WORK
-                com.mashup.dojo.QuestionCategory.HUMOR -> QuestionCategory.HUMOR
-                com.mashup.dojo.QuestionCategory.OTHER -> QuestionCategory.OTHER
-            },
+        when (category) {
+            com.mashup.dojo.QuestionCategory.DATING -> QuestionCategory.DATING
+            com.mashup.dojo.QuestionCategory.FRIENDSHIP -> QuestionCategory.FRIENDSHIP
+            com.mashup.dojo.QuestionCategory.PERSONALITY -> QuestionCategory.PERSONALITY
+            com.mashup.dojo.QuestionCategory.ENTERTAINMENT -> QuestionCategory.ENTERTAINMENT
+            com.mashup.dojo.QuestionCategory.FITNESS -> QuestionCategory.FITNESS
+            com.mashup.dojo.QuestionCategory.APPEARANCE -> QuestionCategory.APPEARANCE
+            com.mashup.dojo.QuestionCategory.WORK -> QuestionCategory.WORK
+            com.mashup.dojo.QuestionCategory.HUMOR -> QuestionCategory.HUMOR
+            com.mashup.dojo.QuestionCategory.OTHER -> QuestionCategory.OTHER
+        },
         emojiImageId = ImageId(emojiImageId)
     )
 }

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -234,13 +234,6 @@ class DefaultQuestionService(
         resolver: MemberId,
     ): List<QuestionSheet> {
         /**
-         * TODO: 여기 있는 애들은 해결된 것일까요?
-         * target : members
-         * question : QuestionSet
-         * candidate : member.candidate()
-         *
-         * - make friend logic, get Candidate logic
-         *
          * ToDo 아래는 추후 캐시에 넣는 작업을 해야합니다.
          * - cache put -> QuestionSet and return
          * - Temporarily set to create for all members, discuss details later

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -10,7 +10,6 @@ import com.mashup.dojo.QuestionSheetEntity
 import com.mashup.dojo.QuestionSheetRepository
 import com.mashup.dojo.Status
 import com.mashup.dojo.domain.ImageId
-import com.mashup.dojo.domain.Member
 import com.mashup.dojo.domain.MemberId
 import com.mashup.dojo.domain.PublishStatus
 import com.mashup.dojo.domain.PublishedTime
@@ -71,9 +70,11 @@ interface QuestionService {
         endAt: LocalDateTime,
     ): QuestionSet
 
-    fun createQuestionSheets(
+    fun createQuestionSheetsForMember(
         questionSet: QuestionSet,
-        members: List<Member>,
+        candidatesOfFriend: List<MemberId>,
+        candidatesOfAccompany: List<MemberId>,
+        resolver: MemberId,
     ): List<QuestionSheet>
 }
 
@@ -224,21 +225,51 @@ class DefaultQuestionService(
     }
 
     @Transactional
-    override fun createQuestionSheets(
+    override fun createQuestionSheetsForMember(
         questionSet: QuestionSet,
-        members: List<Member>,
+        candidatesOfFriend: List<MemberId>,
+        candidatesOfAccompany: List<MemberId>,
+        resolver: MemberId,
     ): List<QuestionSheet> {
         /**
-         * TODO:
+         * TODO: 여기 있는 애들은 해결된 것일까요?
          * target : members
          * question : QuestionSet
          * candidate : member.candidate()
          *
          * - make friend logic, get Candidate logic
+         *
+         * ToDo 아래는 추후 캐시에 넣는 작업을 해야합니다.
          * - cache put -> QuestionSet and return
          * - Temporarily set to create for all members, discuss details later
          */
-        return LIST_SAMPLE_QUESTION_SHEET
+
+        val questionIds = questionSet.questionIds.map { questionOrder -> questionOrder.questionId.value }
+        val friendQuestionIds = questionRepository.findFriendQuestionsByIds(questionIds)
+        val accompanyQuestionIds = questionRepository.findAccompanyQuestionsByIds(questionIds)
+
+        val friendQuestionSheetEntities =
+            friendQuestionIds.map { friendQuestionId ->
+                QuestionSheet.create(
+                    questionSetId = questionSet.id,
+                    questionId = QuestionId(friendQuestionId),
+                    resolverId = resolver,
+                    candidates = candidatesOfFriend
+                ).toEntity()
+            }
+
+        val accompanyQuestionSheetEntities =
+            accompanyQuestionIds.map { friendQuestionId ->
+                QuestionSheet.create(
+                    questionSetId = questionSet.id,
+                    questionId = QuestionId(friendQuestionId),
+                    resolverId = resolver,
+                    candidates = candidatesOfAccompany
+                ).toEntity()
+            }
+
+        val questionSheetEntities = friendQuestionSheetEntities + accompanyQuestionSheetEntities
+        return questionSheetRepository.saveAll(questionSheetEntities).map { it.toQuestionSheetWithCandidatesId() }
     }
 
     override fun getQuestionById(id: QuestionId): Question? {
@@ -376,6 +407,16 @@ private fun QuestionSetEntity.toQuestionSet(): QuestionSet {
         status = status.toDomainPublishStatus(),
         publishedAt = publishedAt,
         endAt = endAt
+    )
+}
+
+private fun QuestionSheet.toEntity(): QuestionSheetEntity {
+    return QuestionSheetEntity(
+        id = questionSheetId.value,
+        questionSetId = questionSetId.value,
+        questionId = questionId.value,
+        resolverId = resolverId.value,
+        candidates = candidates.map { it.value }.toList()
     )
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -124,16 +124,19 @@ class DefaultQuestionUseCase(
         val allMemberRecords = memberService.findAllMember()
         // ToDo Default 친구 수가 8명 이하일 경우 오류 발생하므로, 친구가 8명이 아니면 회원가입 불가능
 
-        return allMemberRecords.flatMap { member ->
-            val candidateOfFriend = memberRelationService.findCandidateOfFriend(member.id)
-            val candidateOfAccompany = memberRelationService.findCandidateOfAccompany(member.id)
-            questionService.createQuestionSheetsForMember(
-                questionSet = currentQuestionSet,
-                candidatesOfFriend = candidateOfFriend,
-                candidatesOfAccompany = candidateOfAccompany,
-                resolver = member.id
-            )
-        }
+        val allMemberQuestionSheets =
+            allMemberRecords.flatMap { member ->
+                val candidateOfFriend = memberRelationService.findCandidateOfFriend(member.id)
+                val candidateOfAccompany = memberRelationService.findCandidateOfAccompany(member.id)
+                questionService.createQuestionSheetsForMember(
+                    questionSet = currentQuestionSet,
+                    candidatesOfFriend = candidateOfFriend,
+                    candidatesOfAccompany = candidateOfAccompany,
+                    resolver = member.id
+                )
+            }
+
+        return questionService.saveQuestionSheets(allMemberQuestionSheets)
     }
 
     override fun getQuestionSheetList(memberId: MemberId): QuestionUseCase.GetQuestionSheetsResult {

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -378,9 +378,6 @@ class DefaultQuestionUseCase(
                 startingQuestionIndex = 1,
                 questionSheetList = TEMP_QUESTION_SHEET_RESULT
             )
-
-        private const val DEFAULT_CANDIDATE_SIZE = 4L
-        private const val DEFAULT_FRIEND_QUESTION_SIZE = 9L
     }
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -13,6 +13,7 @@ import com.mashup.dojo.domain.QuestionSheet
 import com.mashup.dojo.domain.QuestionSheetId
 import com.mashup.dojo.domain.QuestionType
 import com.mashup.dojo.service.ImageService
+import com.mashup.dojo.service.MemberRelationService
 import com.mashup.dojo.service.MemberService
 import com.mashup.dojo.service.PickService
 import com.mashup.dojo.service.QuestionService
@@ -85,6 +86,7 @@ class DefaultQuestionUseCase(
     private val memberService: MemberService,
     private val pickService: PickService,
     private val imageService: ImageService,
+    private val memberRelationService: MemberRelationService,
 ) : QuestionUseCase {
     @Transactional
     override fun create(command: QuestionUseCase.CreateCommand): QuestionId {
@@ -120,7 +122,18 @@ class DefaultQuestionUseCase(
     override fun createQuestionSheet(): List<QuestionSheet> {
         val currentQuestionSet = questionService.getNextOperatingQuestionSet() ?: throw DojoException.of(DojoExceptionType.QUESTION_SET_NOT_READY)
         val allMemberRecords = memberService.findAllMember()
-        return questionService.createQuestionSheets(currentQuestionSet, allMemberRecords)
+        // ToDo Default 친구 수가 8명 이하일 경우 오류 발생하므로, 친구가 8명이 아니면 회원가입 불가능
+
+        return allMemberRecords.flatMap { member ->
+            val candidateOfFriend = memberRelationService.findCandidateOfFriend(member.id)
+            val candidateOfAccompany = memberRelationService.findCandidateOfAccompany(member.id)
+            questionService.createQuestionSheetsForMember(
+                questionSet = currentQuestionSet,
+                candidatesOfFriend = candidateOfFriend,
+                candidatesOfAccompany = candidateOfAccompany,
+                resolver = member.id
+            )
+        }
     }
 
     override fun getQuestionSheetList(memberId: MemberId): QuestionUseCase.GetQuestionSheetsResult {
@@ -365,6 +378,9 @@ class DefaultQuestionUseCase(
                 startingQuestionIndex = 1,
                 questionSheetList = TEMP_QUESTION_SHEET_RESULT
             )
+
+        private const val DEFAULT_CANDIDATE_SIZE = 4L
+        private const val DEFAULT_FRIEND_QUESTION_SIZE = 9L
     }
 }
 

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: api
+  profiles:
+    include: entity, common
+
+dojo:
+  candidate:
+    size: 8
+  


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
QuestionSheet 생성 로직을 구현했습니다. 친구 관계의 질문은 친구 중에서, 비친구 관계의 질문은 비친구 중에서 완전 무작위로 후보자를 선택하는 방식이 예전에 정했던 방법 같아서 그렇게 진행했습니다.

아래와 같이 동작합니다. 혹시나 잘못되거나 틀린 점 있으면 말씀해주세요!
1. 모든 Member를 DB에서 조회합니다.
2. 각 Member에 대해 친구와 비친구를 구분하여 해당 후보자를 가져오는 쿼리를 실행합니다.
3. QuestionSet의 questionIds를 List<친구 질문>과 List<비친구 질문>으로 구분합니다.
4. 분류된 질문 목록과 각각의 후보자를 매칭하여 List<QuestionSheet>를 생성합니다.
5. 생성된 QuestionSheet들을 두 리스트를 합쳐서 반환합니다.
6. `List<QuestionSheet>`를 `List<QuestionEntity>`로 변환하여 DB에 저장후 다시 `List<QuestionSheet>`로 변환하여 반환합니다.

쉽게 설명하려다 보니 좀 길어졌네요,, 긴 글 읽어 주셔서 감사합니다
### 비고 (첨부자료)
현재 친구 수가 8명 미만인 경우 오류가 발생해서, QuestionSheet를 생성하는 스케줄러를 일시적으로 주석 처리하였습니다. 추후 친구 관계가 설정된 이후에 주석을 해제할 예정입니다.