### PR TITLE
fix : 운영/발행예정 QSet 조회 쿼리 수정

### DIFF
--- a/entity/src/main/kotlin/com/mashup/dojo/QuestionSetRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/QuestionSetRepository.kt
@@ -13,17 +13,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
 
 interface QuestionSetRepository : JpaRepository<QuestionSetEntity, String> {
-    // publishedYn : True && publishedAt > now -> 현재 운영중인 QuestionSet
-    fun findByPublishedAtAfterAndEndAtBefore(
+    // publishedAt < now < endAt -> 현재 운영중인 QuestionSet
+    fun findByPublishedAtBeforeAndEndAtAfterOrderByPublishedAtAsc(
         publishedCompareTime: LocalDateTime = LocalDateTime.now(),
         endTimeCompareTime: LocalDateTime = LocalDateTime.now(),
     ): QuestionSetEntity?
 
-    // publishedYn : True && publishedAt < now -> 발행 직전(예정) QuestionSet
-    fun findByStatusAndPublishedAtAfter(
-        status: Status,
-        compareTime: LocalDateTime = LocalDateTime.now(),
-    ): QuestionSetEntity?
+    // publishedAt > now && 가장 작은 publishedAt -> 발행 직전(예정) QuestionSet
+    fun findFirstByPublishedAtAfterOrderByPublishedAtAsc(compareTime: LocalDateTime = LocalDateTime.now()): QuestionSetEntity?
 
     fun findTopByOrderByPublishedAtDesc(): QuestionSetEntity?
 }

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -116,7 +116,7 @@ class DefaultQuestionService(
 
     // 현재 운영중인 QuestionSet
     override fun getOperatingQuestionSet(): QuestionSet? {
-        return questionSetRepository.findByPublishedAtAfterAndEndAtBefore(LocalDateTime.now(), LocalDateTime.now())
+        return questionSetRepository.findByPublishedAtBeforeAndEndAtAfterOrderByPublishedAtAsc()
             ?.toQuestionSet() ?: run {
             log.error { "Published And Operating QuestionSet Entity not found" }
             null
@@ -125,8 +125,7 @@ class DefaultQuestionService(
 
     // 발행 출격 준비 완료 QuestionSet
     override fun getNextOperatingQuestionSet(): QuestionSet? {
-        return questionSetRepository.findByStatusAndPublishedAtAfter(Status.UPCOMING, LocalDateTime.now())
-            ?.toQuestionSet() ?: run {
+        return questionSetRepository.findFirstByPublishedAtAfterOrderByPublishedAtAsc()?.toQuestionSet() ?: run {
             log.error { "Published And Prepared for sortie QuestionSet Entity not found" }
             null
         }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- QSheet 만들어졌는지 확인하려했는데, EB 들어가보니 에러로그 확인되어 버그 수정합니다. 

### 비고 (첨부자료)
```
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: 2024-08-16 09:05:00.144 ERROR 391860 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: org.springframework.dao.IncorrectResultSizeDataAccessException: Query did not return a unique result: 4 results were returned
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.orm.jpa.vendor.HibernateJpaDialect.convertHibernateAccessException(HibernateJpaDialect.java:301)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:244)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:550)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:335)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:152)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:136)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.data.repository.core.support.MethodInvocationValidator.invoke(MethodInvocationValidator.java:95)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at jdk.proxy2/jdk.proxy2.$Proxy161.findByStatusAndPublishedAtAfter(Unknown Source)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at com.mashup.dojo.service.DefaultQuestionService.getNextOperatingQuestionSet(QuestionService.kt:128)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.lang.reflect.Method.invoke(Method.java:580)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:354)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:392)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at com.mashup.dojo.service.DefaultQuestionService$$SpringCGLIB$$0.getNextOperatingQuestionSet(<generated>)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at com.mashup.dojo.usecase.DefaultQuestionUseCase.createQuestionSheet(QuestionUseCase.kt:123)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.lang.reflect.Method.invoke(Method.java:580)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:354)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:392)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at com.mashup.dojo.usecase.DefaultQuestionUseCase$$SpringCGLIB$$0.createQuestionSheet(<generated>)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at com.mashup.dojo.scheduler.Scheduler.createQuestionSheet(Scheduler.kt:29)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.lang.reflect.Method.invoke(Method.java:580)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.scheduling.support.ScheduledMethodRunnable.runInternal(ScheduledMethodRunnable.java:130)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.scheduling.support.ScheduledMethodRunnable.lambda$run$2(ScheduledMethodRunnable.java:124)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at io.micrometer.observation.Observation.observe(Observation.java:499)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:124)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at org.springframework.scheduling.concurrent.ReschedulingRunnable.run(ReschedulingRunnable.java:96)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: #011at java.base/java.lang.Thread.run(Thread.java:1583)
Aug 16 00:05:00 ip-172-31-12-84 web[391860]: Caused by: org.hibernate.NonUniqueResultException: Query did not return a unique result: 4 results were returned

```