### PR TITLE
feat: picklist paging logic

### DIFF
--- a/_endpoint_test/pick.http
+++ b/_endpoint_test/pick.http
@@ -1,6 +1,5 @@
 ### 내가 받은 픽 리스트 조회하기
-
-GET {{host}}/pick/picked-list?sort=MOST_PICKED
+GET {{host}}/pick/picked-list?pageSize=10&pageNumber=0&sort=MOST_PICKED
 
 ### 내가 받은 픽 중 특정 질문의 페이징 조회하기
 GET {{host}}/pick/picked-detail?questionId=abc

--- a/api/src/main/kotlin/com/mashup/dojo/PickController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/PickController.kt
@@ -84,11 +84,11 @@ class PickController(
         @RequestParam(required = false, defaultValue = "10") pageSize: Int,
     ): DojoApiResponse<PickPaging> {
         val currentMemberId = MemberPrincipalContextHolder.current().id
-        val pickPaging: PickUseCase.GetPagingPick =
+        val pickDetailPaging: PickUseCase.GetPickDetailPaging =
             pickUseCase.getReceivedPickDetailPaging(PickUseCase.GetPagingPickCommand(currentMemberId, QuestionId(questionId), pageNumber, pageSize))
 
         val pickDetails =
-            pickPaging.picks.map {
+            pickDetailPaging.picks.map {
                 ReceivedPickDetail(
                     pickId = it.pickId,
                     pickerOrdinal = it.pickerOrdinal,
@@ -107,16 +107,16 @@ class PickController(
             }
         val pickPagingResponse =
             PickPaging(
-                questionId = pickPaging.questionId,
-                questionContent = pickPaging.questionContent,
-                questionEmojiImageUrl = pickPaging.questionEmojiImageUrl,
-                totalReceivedPickCount = pickPaging.totalReceivedPickCount,
-                anyOpenPickerCount = pickPaging.anyOpenPickerCount,
+                questionId = pickDetailPaging.questionId,
+                questionContent = pickDetailPaging.questionContent,
+                questionEmojiImageUrl = pickDetailPaging.questionEmojiImageUrl,
+                totalReceivedPickCount = pickDetailPaging.totalReceivedPickCount,
+                anyOpenPickerCount = pickDetailPaging.anyOpenPickerCount,
                 picks = pickDetails,
-                totalPage = pickPaging.totalPage,
-                totalElements = pickPaging.totalElements,
-                isFirst = pickPaging.isFirst,
-                isLast = pickPaging.isLast
+                totalPage = pickDetailPaging.totalPage,
+                totalElements = pickDetailPaging.totalElements,
+                isFirst = pickDetailPaging.isFirst,
+                isLast = pickDetailPaging.isLast
             )
 
         return DojoApiResponse.success(pickPagingResponse)

--- a/api/src/main/kotlin/com/mashup/dojo/PickController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/PickController.kt
@@ -8,15 +8,17 @@ import com.mashup.dojo.domain.PickOpenItem
 import com.mashup.dojo.domain.PickSort
 import com.mashup.dojo.domain.QuestionId
 import com.mashup.dojo.dto.CreatePickRequest
+import com.mashup.dojo.dto.PickDetailPaging
 import com.mashup.dojo.dto.PickOpenItemDto
 import com.mashup.dojo.dto.PickOpenRequest
 import com.mashup.dojo.dto.PickOpenResponse
-import com.mashup.dojo.dto.PickPaging
 import com.mashup.dojo.dto.PickResponse
 import com.mashup.dojo.dto.ReceivedPickDetail
-import com.mashup.dojo.dto.ReceivedPickListGetResponse
+import com.mashup.dojo.dto.ReceivedPickPagingGetResponse
 import com.mashup.dojo.usecase.PickUseCase
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -37,27 +39,44 @@ class PickController(
 ) {
     @GetMapping("/picked-list")
     @Operation(
-        summary = "내가 받은 픽 List API",
-        description = "내가 받은 픽들을 정렬하여 보여주는 API. default sort : 최신 순",
+        summary = "내가 받은 픽 페이징 API",
+        description = "내가 받은 픽들을 페이징 처리 후 정렬하여 보여주는 API. default sort : 최신 순",
         responses = [
-            ApiResponse(responseCode = "200", description = "내가 받은 픽 리스트")
+            ApiResponse(responseCode = "200", description = "내가 받은 픽 리스트 페이징")
         ]
     )
     fun getReceivedPickList(
-        // todo : add userinfo
-        @RequestParam(required = false, defaultValue = "LATEST") sort: PickSort,
-    ): DojoApiResponse<ReceivedPickListGetResponse> {
+        @Parameter(
+            description = "정렬 기준. LATEST는 최근에 Pick된 항목을 기준으로 정렬하고, MOST_PICKED는 가장 많이 Pick된 항목을 기준으로 정렬합니다.",
+            schema = Schema(defaultValue = "LATEST")
+        )
+        @RequestParam(required = false, defaultValue = "LATEST") sort: String,
+        @Parameter(
+            description = "페이지 번호. 0부터 시작합니다.",
+            schema = Schema(defaultValue = "0")
+        )
+        @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
+        @Parameter(
+            description = "페이지 크기. 한 페이지에 포함될 항목의 개수를 설정합니다.",
+            schema = Schema(defaultValue = "10")
+        )
+        @RequestParam(required = false, defaultValue = "10") pageSize: Int,
+    ): DojoApiResponse<ReceivedPickPagingGetResponse> {
         val currentMemberId = MemberPrincipalContextHolder.current().id
-        val receivedPickList: List<PickUseCase.GetReceivedPick> =
+        val validSort = PickSort.findByValue(sort)
+
+        val receivedPickList =
             pickUseCase.getReceivedPickList(
-                PickUseCase.GetReceivedPickListCommand(
+                PickUseCase.GetReceivedPickPagingCommand(
                     memberId = currentMemberId,
-                    sort = sort
+                    sort = validSort,
+                    pageNumber = pageNumber,
+                    pageSize = pageSize
                 )
             )
 
         val pickResponseList =
-            receivedPickList.map {
+            receivedPickList.picks.map {
                 PickResponse(
                     pickId = it.pickId,
                     questionId = it.questionId,
@@ -67,7 +86,19 @@ class PickController(
                     latestPickedAt = it.latestPickedAt
                 )
             }
-        return DojoApiResponse.success(ReceivedPickListGetResponse(pickResponseList, sort))
+
+        return DojoApiResponse.success(
+            ReceivedPickPagingGetResponse(
+                pickList = pickResponseList,
+                totalPage = receivedPickList.totalPage,
+                totalElements = receivedPickList.totalElements,
+                isFirst = receivedPickList.isFirst,
+                isLast = receivedPickList.isLast,
+                sort = validSort,
+                pageNumber = pageNumber,
+                pageSize = pageSize
+            )
+        )
     }
 
     @GetMapping("/picked-detail")
@@ -82,7 +113,7 @@ class PickController(
         @RequestParam questionId: String,
         @RequestParam(required = false, defaultValue = "0") pageNumber: Int,
         @RequestParam(required = false, defaultValue = "10") pageSize: Int,
-    ): DojoApiResponse<PickPaging> {
+    ): DojoApiResponse<PickDetailPaging> {
         val currentMemberId = MemberPrincipalContextHolder.current().id
         val pickDetailPaging: PickUseCase.GetPickDetailPaging =
             pickUseCase.getReceivedPickDetailPaging(PickUseCase.GetPagingPickCommand(currentMemberId, QuestionId(questionId), pageNumber, pageSize))
@@ -105,8 +136,8 @@ class PickController(
                     latestPickedAt = it.latestPickedAt
                 )
             }
-        val pickPagingResponse =
-            PickPaging(
+        val pickDetailPagingResponse =
+            PickDetailPaging(
                 questionId = pickDetailPaging.questionId,
                 questionContent = pickDetailPaging.questionContent,
                 questionEmojiImageUrl = pickDetailPaging.questionEmojiImageUrl,
@@ -119,7 +150,7 @@ class PickController(
                 isLast = pickDetailPaging.isLast
             )
 
-        return DojoApiResponse.success(pickPagingResponse)
+        return DojoApiResponse.success(pickDetailPagingResponse)
     }
 
     @PostMapping

--- a/api/src/main/kotlin/com/mashup/dojo/dto/PickDto.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/PickDto.kt
@@ -26,9 +26,15 @@ data class CreatePickRequest(
     val pickedId: MemberId,
 )
 
-data class ReceivedPickListGetResponse(
+data class ReceivedPickPagingGetResponse(
     val pickList: List<PickResponse>,
+    val totalPage: Int,
+    val totalElements: Long,
+    val isFirst: Boolean,
+    val isLast: Boolean,
     val sort: PickSort,
+    val pageNumber: Int,
+    val pageSize: Int,
 )
 
 // todo : 질문의 유형(카테고리)도 전달해줘야 하는가
@@ -41,7 +47,7 @@ data class PickResponse(
     val latestPickedAt: LocalDateTime,
 )
 
-data class PickPaging(
+data class PickDetailPaging(
     val questionId: QuestionId,
     val questionContent: String,
     val questionEmojiImageUrl: String,

--- a/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
+++ b/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
@@ -47,4 +47,7 @@ enum class DojoExceptionType(
 
     // MemberRelation
     RELATION_NOT_FOUND("Relation not found", "MR001_RELATION_NOT_FOUND", 500),
+
+    // Pick Paging Sort
+    SORT_NOT_FOUND("Relation not found", "SORT_NOT_FOUND", 500),
 }

--- a/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
+++ b/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
@@ -49,5 +49,6 @@ enum class DojoExceptionType(
     RELATION_NOT_FOUND("Relation not found", "MR001_RELATION_NOT_FOUND", 500),
 
     // Pick Paging Sort
-    SORT_NOT_FOUND("Relation not found", "SORT_NOT_FOUND", 500),
+    SORT_CLIENT_NOT_FOUND("Bad SortType", "SORT_NOT_FOUND", 400),
+    SORT_NOT_FOUND("Sort Type not found", "SORT_NOT_FOUND", 500),
 }

--- a/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
@@ -282,15 +282,10 @@ class PickRepositoryImpl(
         query: JPAQuery<PickQuestionDetailMapper>,
     ): JPAQuery<PickQuestionDetailMapper> {
         val pickEntity = QPickEntity.pickEntity
-        if (sort == PickSort.MOST_PICKED.name) {
-            return query.orderBy(Wildcard.count.desc(), pickEntity.createdAt.desc())
+        return when (PickSort.findByValue(sort)) {
+            PickSort.MOST_PICKED -> query.orderBy(Wildcard.count.desc(), pickEntity.createdAt.desc())
+            PickSort.LATEST -> query.orderBy(pickEntity.createdAt.desc())
         }
-
-        if (sort == PickSort.LATEST.name) {
-            return query.orderBy(pickEntity.createdAt.desc())
-        }
-
-        throw DojoException.of(DojoExceptionType.SORT_NOT_FOUND)
     }
 
     private fun getGroupByPickTotalCount(pickedId: String): Long {
@@ -338,6 +333,14 @@ data class PickQuestionMapper
 enum class PickSort {
     LATEST,
     MOST_PICKED,
+    ;
+
+    companion object {
+        fun findByValue(value: String): PickSort {
+            return PickSort.entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw DojoException.of(DojoExceptionType.SORT_CLIENT_NOT_FOUND)
+        }
+    }
 }
 
 data class PickQuestionDetailMapper

--- a/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/PickRepository.kt
@@ -4,6 +4,7 @@ import com.mashup.dojo.base.BaseTimeEntity
 import com.querydsl.core.annotations.QueryProjection
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Wildcard
+import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -72,6 +73,12 @@ interface PickRepositoryCustom {
         memberId: String,
         rank: Long,
     ): List<PickQuestionMapper>
+
+    fun findGroupByPickPaging(
+        pickedId: String,
+        sort: String,
+        pageable: Pageable,
+    ): Page<PickQuestionDetailMapper>
 }
 
 class PickRepositoryImpl(
@@ -221,6 +228,80 @@ class PickRepositoryImpl(
             .limit(rank)
             .fetch()
     }
+
+    override fun findGroupByPickPaging(
+        pickedId: String,
+        sort: String,
+        pageable: Pageable,
+    ): Page<PickQuestionDetailMapper> {
+        val content = getGroupByPickContent(pickedId, sort, pageable)
+        val totalCount = getGroupByPickTotalCount(pickedId)
+
+        return PageImpl(content, pageable, totalCount)
+    }
+
+    private fun getGroupByPickContent(
+        pickedId: String,
+        sort: String,
+        pageable: Pageable,
+    ): List<PickQuestionDetailMapper> {
+        val pickEntity = QPickEntity.pickEntity
+        val questionEntity = QQuestionEntity.questionEntity
+        val imageEntity = QImageEntity.imageEntity
+
+        val query =
+            jpaQueryFactory
+                .select(
+                    QPickQuestionDetailMapper(
+                        pickEntity.id,
+                        questionEntity.id,
+                        questionEntity.content,
+                        imageEntity.url,
+                        // 가장 최근의 Pick 시간 가져오기
+                        pickEntity.createdAt.max().`as`("latestPickedAt"),
+                        pickEntity.id.count().`as`("totalReceivedPickCount")
+                    )
+                )
+                .from(pickEntity)
+                .join(questionEntity).on(pickEntity.questionId.eq(questionEntity.id))
+                .join(imageEntity).on(questionEntity.emojiImageId.eq(imageEntity.id))
+                .where(pickEntity.pickedId.eq(pickedId))
+                // Question, Image URL 기준으로 그룹화
+                .groupBy(pickEntity.questionId, imageEntity.url)
+
+        val sortedQuery = getSorted(sort, query)
+
+        return sortedQuery
+            .limit(pageable.pageSize.toLong())
+            .offset(pageable.offset)
+            .fetch()
+    }
+
+    private fun getSorted(
+        sort: String,
+        query: JPAQuery<PickQuestionDetailMapper>,
+    ): JPAQuery<PickQuestionDetailMapper> {
+        val pickEntity = QPickEntity.pickEntity
+        if (sort == PickSort.MOST_PICKED.name) {
+            return query.orderBy(Wildcard.count.desc(), pickEntity.createdAt.desc())
+        }
+
+        if (sort == PickSort.LATEST.name) {
+            return query.orderBy(pickEntity.createdAt.desc())
+        }
+
+        throw DojoException.of(DojoExceptionType.SORT_NOT_FOUND)
+    }
+
+    private fun getGroupByPickTotalCount(pickedId: String): Long {
+        val pickEntity = QPickEntity.pickEntity
+
+        return jpaQueryFactory
+            .select(pickEntity.questionId.countDistinct())
+            .from(pickEntity)
+            .where(pickEntity.pickedId.eq(pickedId))
+            .fetchOne() ?: 0L
+    }
 }
 
 data class PickEntityMapper
@@ -252,4 +333,20 @@ data class PickQuestionMapper
         val questionId: String,
         val questionContent: String,
         val createdAt: LocalDateTime,
+    )
+
+enum class PickSort {
+    LATEST,
+    MOST_PICKED,
+}
+
+data class PickQuestionDetailMapper
+    @QueryProjection
+    constructor(
+        val pickId: String,
+        val questionId: String,
+        val questionContent: String,
+        val questionEmojiImageUrl: String,
+        val latestPickedAt: LocalDateTime,
+        val totalReceivedPickCount: Long,
     )

--- a/service/src/main/kotlin/com/mashup/dojo/domain/Pick.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/Pick.kt
@@ -100,4 +100,12 @@ enum class PickOpenItem(val value: String, val cost: Int) {
 enum class PickSort {
     LATEST,
     MOST_PICKED,
+    ;
+
+    companion object {
+        fun findByValue(value: String): PickSort {
+            return PickSort.entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw DojoException.of(DojoExceptionType.SORT_CLIENT_NOT_FOUND)
+        }
+    }
 }

--- a/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 
 interface PickService {
-    fun getReceivedPickList(
+    fun getReceivedPickPaging(
         pickedMemberId: MemberId,
         sort: PickSort,
     ): List<Pick>
@@ -48,12 +48,12 @@ interface PickService {
         pickOpenItem: PickOpenItem,
     ): String
 
-    fun getPickPaging(
+    fun getPickDetailPaging(
         questionId: QuestionId,
         memberId: MemberId,
         pageNumber: Int,
         pageSize: Int,
-    ): GetPagingPick
+    ): GetPickDetailPaging
 
     fun getPickCount(
         questionId: QuestionId,
@@ -70,8 +70,8 @@ interface PickService {
     ): Int
 
     fun getReceivedMySpacePicks(memberId: MemberId): List<MySpacePickDetail>
-
-    data class GetPagingPick(
+    
+    data class GetPickDetailPaging(
         val picks: List<GetReceivedPickDetail>,
         val totalPage: Int,
         val totalElements: Long,
@@ -113,7 +113,7 @@ class DefaultPickService(
     @Value("\${dojo.rank.size}")
     private val defaultRankSize: Long,
 ) : PickService {
-    override fun getReceivedPickList(
+    override fun getReceivedPickPaging(
         pickedMemberId: MemberId,
         sort: PickSort,
     ): List<Pick> {
@@ -178,12 +178,12 @@ class DefaultPickService(
         return pickRepository.findByIdOrNull(pickId.value)?.toPick()
     }
 
-    override fun getPickPaging(
+    override fun getPickDetailPaging(
         questionId: QuestionId,
         memberId: MemberId,
         pageNumber: Int,
         pageSize: Int,
-    ): PickService.GetPagingPick {
+    ): PickService.GetPickDetailPaging {
         val pageable = PageRequest.of(pageNumber, pageSize)
         val pagingPick = pickRepository.findPickDetailPaging(memberId = memberId.value, questionId = questionId.value, pageable = pageable)
 
@@ -219,7 +219,7 @@ class DefaultPickService(
                 )
             }
 
-        return PickService.GetPagingPick(
+        return PickService.GetPickDetailPaging(
             picks = receivedPickDetails,
             totalPage = pagingPick.totalPages,
             totalElements = pagingPick.totalElements,

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
@@ -44,7 +44,7 @@ interface PickUseCase {
         val pageSize: Int,
     )
 
-    data class GetPagingPick(
+    data class GetPickDetailPaging(
         val questionId: QuestionId,
         val questionContent: String,
         val questionEmojiImageUrl: String,
@@ -85,7 +85,7 @@ interface PickUseCase {
 
     fun openPick(openPickCommand: OpenPickCommand): PickOpenInfo
 
-    fun getReceivedPickDetailPaging(command: GetPagingPickCommand): GetPagingPick
+    fun getReceivedPickDetailPaging(command: GetPagingPickCommand): GetPickDetailPaging
 }
 
 @Component
@@ -97,7 +97,7 @@ class DefaultPickUseCase(
     private val notificationService: NotificationService,
 ) : PickUseCase {
     override fun getReceivedPickList(command: GetReceivedPickListCommand): List<GetReceivedPick> {
-        val receivedPickList: List<Pick> = pickService.getReceivedPickList(command.memberId, command.sort)
+        val receivedPickList: List<Pick> = pickService.getReceivedPickPaging(command.memberId, command.sort)
 
         if (receivedPickList.isEmpty()) return EMPTY_RECEIVED_PICK
 
@@ -166,7 +166,7 @@ class DefaultPickUseCase(
         ).let { PickOpenInfo(openPickCommand.pickId, openPickCommand.pickOpenItem, it) }
     }
 
-    override fun getReceivedPickDetailPaging(command: PickUseCase.GetPagingPickCommand): PickUseCase.GetPagingPick {
+    override fun getReceivedPickDetailPaging(command: PickUseCase.GetPagingPickCommand): PickUseCase.GetPickDetailPaging {
         val question =
             questionService.getQuestionById(command.questionId)
                 ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "등록되지 않은 QuestionId 입니다. QuestionId: [${command.questionId}]")
@@ -177,11 +177,11 @@ class DefaultPickUseCase(
 
         val pickCount: Int = pickService.getPickCount(question.id, command.memberId)
 
-        val receivedPickPaging = pickService.getPickPaging(question.id, command.memberId, command.pageNumber, command.pageSize)
+        val receivedPickPaging = pickService.getPickDetailPaging(question.id, command.memberId, command.pageNumber, command.pageSize)
 
         val anyOpenPickerCount = pickService.getAnyOpenPickerCount(question.id, command.memberId)
 
-        return PickUseCase.GetPagingPick(
+        return PickUseCase.GetPickDetailPaging(
             questionId = question.id,
             questionContent = question.content,
             questionEmojiImageUrl = imageUrl,


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용

1. 기존 모든 픽을 반환하던 것을 페이징처리하여 반환합니다.
2. 기존 N + 1 문제가 발생하던 것을 조인하여 2번의 쿼리로 한 번에 처리합니다.
3. pickDetail 페이징과 객체명이 혼란스러워 pickPaging 과 pickDetailPaging으로 구분했습니다.

### 비고 (첨부자료)
![pickpagingapi](https://github.com/user-attachments/assets/38e97dce-7658-4f60-ac2a-222decb8874e)
