### PR TITLE
fix: token parsing issue by removing Bearer prefix and trimming spaces

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/JwtTokenService.kt
@@ -3,6 +3,7 @@ package com.mashup.dojo.config.security
 import com.mashup.dojo.DojoException
 import com.mashup.dojo.DojoExceptionType
 import com.mashup.dojo.domain.MemberId
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.Jwts.SIG
@@ -17,6 +18,8 @@ class MemberAuthToken(
         return credentials
     }
 }
+
+private val logger = KotlinLogging.logger { }
 
 class JwtTokenService(
     private val secretKey: String,
@@ -65,6 +68,10 @@ class JwtTokenService(
                 .build()
                 .parseSignedClaims(token.credentials)
                 .payload
-        }.getOrElse { throw DojoException.of(DojoExceptionType.INVALID_TOKEN) }
+        }.onFailure { error ->
+            logger.info { "Error parsing token: ${error.message}" }
+        }.getOrElse {
+            throw DojoException.of(DojoExceptionType.INVALID_TOKEN)
+        }
     }
 }

--- a/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/config/security/MemberAuthTokenAuthenticationFilter.kt
@@ -42,8 +42,16 @@ class MemberAuthTokenAuthenticationFilter(
 
     private fun resolveMemberAuthToken(request: HttpServletRequest): MemberAuthToken? {
         return kotlin.runCatching {
-            val token = request.getHeader(AUTHORIZATION_HEADER_NAME)
-            MemberAuthToken(token)
+            // 헤더 자체를 trim
+            val header = request.getHeader(AUTHORIZATION_HEADER_NAME)?.trim()
+            logger.info("Authorization header = $header")
+
+            // "Bearer " 접두사 제거
+            val token = header?.takeIf { it.startsWith(BEARER_PREFIX) }?.substring(BEARER_START_INDEX)?.trim()
+            logger.info("Token after removing Bearer and trimming = $token")
+
+            // token이 null이 아닌 경우에만 MemberAuthToken 생성
+            token?.let { MemberAuthToken(it) }
         }.getOrNull()
     }
 
@@ -69,5 +77,7 @@ class MemberAuthTokenAuthenticationFilter(
 
     companion object {
         private const val AUTHORIZATION_HEADER_NAME = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+        private const val BEARER_START_INDEX = 7
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
Authorization Header에서 JWT Token 추출시 Bearer prefix를 제거하지 않아 인증 되지 않던 문제를 해결했습니다.

### 비고 (첨부자료)
