### PR TITLE
feat; 내 정보 조회 시 카운트 값만 Mock으로 내려요

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/MemberController.kt
@@ -12,6 +12,7 @@ import com.mashup.dojo.dto.MemberProfileResponse
 import com.mashup.dojo.dto.MemberSearchResponse
 import com.mashup.dojo.dto.MemberUpdateRequest
 import com.mashup.dojo.dto.MyProfileResponse
+import com.mashup.dojo.service.ImageService
 import com.mashup.dojo.service.MemberService
 import com.mashup.dojo.usecase.MemberUseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -36,6 +37,7 @@ private val logger = KotlinLogging.logger { }
 class MemberController(
     private val memberUseCase: MemberUseCase,
     private val memberService: MemberService,
+    private val imageService: ImageService,
     private val jwtTokenService: JwtTokenService,
 ) {
     @PostMapping("/public/member")
@@ -125,9 +127,22 @@ class MemberController(
         val memberId = MemberPrincipalContextHolder.current().id
 
         logger.info { "read my profile, $memberId" }
+        val member = memberService.findMemberById(memberId) ?: throw DojoException.of(DojoExceptionType.MEMBER_NOT_FOUND)
+        val profileImage = imageService.load(member.profileImageId) ?: throw DojoException.of(DojoExceptionType.IMAGE_NOT_FOUND)
 
-        // TODO 로직 연결
-        return DojoApiResponse.success(MyProfileResponse.mock())
+        return DojoApiResponse.success(
+            MyProfileResponse(
+                memberId = member.id.value,
+                profileImageUrl = profileImage.url,
+                memberName = member.fullName,
+                platform = member.platform.name,
+                ordinal = member.ordinal,
+                // TODO MOCK 값들 채우기
+                pickCount = 10,
+                friendCount = 20,
+                coinCount = 0
+            )
+        )
     }
 
     // ToDo 로직 연결 후 추후 제거

--- a/api/src/main/kotlin/com/mashup/dojo/dto/MyProfileResponse.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/MyProfileResponse.kt
@@ -20,18 +20,4 @@ data class MyProfileResponse(
     val friendCount: Int,
     @Schema(description = "소유한 코인 개수")
     val coinCount: Int,
-) {
-    companion object {
-        fun mock() =
-            MyProfileResponse(
-                memberId = "memberI123456754231",
-                profileImageUrl = "https://t1.daumcdn.net/daumtop_chanel/op/20200723055344399.png",
-                memberName = "낭은영",
-                platform = "Product Design",
-                ordinal = 14,
-                pickCount = 8186,
-                friendCount = 1925,
-                coinCount = 3994
-            )
-    }
-}
+)

--- a/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
+++ b/common/src/main/kotlin/com/mashup/dojo/DojoExceptionType.kt
@@ -18,6 +18,7 @@ enum class DojoExceptionType(
     INVALID_MEMBER_GENDER("The gender does not exist.", "C011_INVALID_MEMBER_GENDER", 400),
     INVALID_MEMBER_PLATFORM("The platform does not exist.", "C010_INVALID_MEMBER_PLATFORM", 400),
     MEMBER_NOT_FOUND("Member not found", "C012_MEMBER_NOT_FOUND", 400),
+    IMAGE_NOT_FOUND("Image not found", "C013_IMAGE_NOT_FOUND", 400),
 
     // pick
     PICK_NOT_FOUND("Pick not found", "C050_PICK_NOT_FOUND", 400),


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
내 정보 조회하기 원래 mock이었는데 요청한 멤버의 정보 내리되, count값만 목으로 냄겨놔요
