### PR TITLE
fix: pick detail field UNKNOWN to null

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/PickController.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/PickController.kt
@@ -119,11 +119,14 @@ class PickController(
 
         val pickDetails =
             pickDetailPaging.picks.map {
+                val pickId = if (it.pickId.value == "UNKNOWN") null else it.pickId
+                val pickerId = if (it.pickerId.value == "UNKNOWN") null else it.pickId
+
                 ReceivedPickDetail(
-                    pickId = it.pickId,
+                    pickId = pickId,
                     pickerOrdinal = it.pickerOrdinal,
                     pickerIdOpen = it.pickerIdOpen,
-                    pickerId = it.pickerId,
+                    pickerId = pickerId,
                     pickerGenderOpen = it.pickerGenderOpen,
                     pickerGender = it.pickerGender,
                     pickerPlatformOpen = it.pickerPlatformOpen,

--- a/api/src/main/kotlin/com/mashup/dojo/dto/PickDto.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/PickDto.kt
@@ -61,18 +61,18 @@ data class PickDetailPaging(
 )
 
 data class ReceivedPickDetail(
-    val pickId: PickId,
+    val pickId: PickId?,
     val pickerOrdinal: Int,
     val pickerIdOpen: Boolean,
-    val pickerId: MemberId,
+    val pickerId: PickId?,
     val pickerGenderOpen: Boolean,
-    val pickerGender: MemberGender,
+    val pickerGender: MemberGender?,
     val pickerPlatformOpen: Boolean,
-    val pickerPlatform: MemberPlatform,
+    val pickerPlatform: MemberPlatform?,
     val pickerSecondInitialNameOpen: Boolean,
-    val pickerSecondInitialName: String,
+    val pickerSecondInitialName: String?,
     val pickerFullNameOpen: Boolean,
-    val pickerFullName: String,
+    val pickerFullName: String?,
     val latestPickedAt: LocalDateTime,
 )
 

--- a/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/DefaultPickService.kt
@@ -104,13 +104,13 @@ interface PickService {
         val pickerIdOpen: Boolean,
         val pickerId: MemberId,
         val pickerGenderOpen: Boolean,
-        val pickerGender: MemberGender,
+        val pickerGender: MemberGender?,
         val pickerPlatformOpen: Boolean,
-        val pickerPlatform: MemberPlatform,
+        val pickerPlatform: MemberPlatform?,
         val pickerSecondInitialNameOpen: Boolean,
-        val pickerSecondInitialName: String,
+        val pickerSecondInitialName: String?,
         val pickerFullNameOpen: Boolean,
-        val pickerFullName: String,
+        val pickerFullName: String?,
         val latestPickedAt: LocalDateTime,
     )
 
@@ -288,41 +288,41 @@ class DefaultPickService(
     fun transformPickerGender(
         isOpen: Boolean,
         pickerGender: MemberGender,
-    ): MemberGender {
+    ): MemberGender? {
         if (isOpen) {
             return pickerGender
         }
-        return MemberGender.UNKNOWN
+        return null
     }
 
     fun transformPickerPlatform(
         isOpen: Boolean,
         pickerPlatform: MemberPlatform,
-    ): MemberPlatform {
+    ): MemberPlatform? {
         if (isOpen) {
             return pickerPlatform
         }
-        return MemberPlatform.UNKNOWN
+        return null
     }
 
     fun transformPickerSecondInitialName(
         isOpen: Boolean,
         secondInitialName: String,
-    ): String {
+    ): String? {
         if (isOpen) {
             return secondInitialName
         }
-        return UNKNOWN
+        return null
     }
 
     fun transformPickerFullName(
         isOpen: Boolean,
         fullName: String,
-    ): String {
+    ): String? {
         if (isOpen) {
             return fullName
         }
-        return UNKNOWN
+        return null
     }
 
     override fun getPickCount(


### PR DESCRIPTION
pickId, pickerId, pickerGender, pickerPlatform, pickerSecondInitialName, pickerFullName

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
pickId, pickerId, pickerGender, pickerPlatform, pickerSecondInitialName, pickerFullName  필드를 UNKNOWN에서 null로 수정했습니다.

### 비고 (첨부자료)
