### PR TITLE
QSheet 생성시 사용된 QSet 상태 변경

### DIFF
--- a/entity/src/main/kotlin/com/mashup/dojo/QuestionSetRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/QuestionSetRepository.kt
@@ -20,7 +20,10 @@ interface QuestionSetRepository : JpaRepository<QuestionSetEntity, String> {
     ): QuestionSetEntity?
 
     // publishedAt > now && 가장 작은 publishedAt -> 발행 직전(예정) QuestionSet
-    fun findFirstByPublishedAtAfterOrderByPublishedAtAsc(compareTime: LocalDateTime = LocalDateTime.now()): QuestionSetEntity?
+    fun findFirstByStatusAndPublishedAtAfterOrderByPublishedAtAsc(
+        status: Status,
+        compareTime: LocalDateTime = LocalDateTime.now(),
+    ): QuestionSetEntity?
 
     fun findTopByOrderByPublishedAtDesc(): QuestionSetEntity?
 }
@@ -45,6 +48,7 @@ class QuestionSetEntity(
 enum class Status {
     TERMINATED, // 종료
     ACTIVE, // 운영중
+    READY, // QSheet 까지 만들어진 경우
     UPCOMING, // 예정
 }
 

--- a/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/domain/QuestionSet.kt
@@ -21,6 +21,8 @@ data class QuestionSet(
     val publishedAt: LocalDateTime,
     val endAt: LocalDateTime,
 ) {
+    fun updateToReady() = this.copy(status = PublishStatus.READY)
+
     companion object {
         fun create(
             questionOrders: List<QuestionOrder>,
@@ -40,5 +42,6 @@ data class QuestionSet(
 enum class PublishStatus {
     TERMINATED, // 종료
     ACTIVE, // 운영중
+    READY, // QSheet 생성까지 준비 완료
     UPCOMING, // 예정
 }

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -154,7 +154,10 @@ class DefaultQuestionUseCase(
                 questionSheets
             }
 
-        return questionService.saveQuestionSheets(allMemberQuestionSheets)
+        val questionSheetList = questionService.saveQuestionSheets(allMemberQuestionSheets)
+        // QSheet 생성 완료된 QSet 상태 변경
+        questionService.updateQuestionSetToReady(currentQuestionSet)
+        return questionSheetList
     }
 
     override fun getQuestionSheetList(memberId: MemberId): QuestionUseCase.GetQuestionSheetsResult {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
QSheet 생성 스케줄 동작시, 이미 만들어진 QSet 이 다중으로 모두 배포 예정 이전일 때, 가장 현재에 가까운 QSet 을 계속 가져와 만들어지고 있는 문제 수정 
- QSet Enum 값 READY (QSheet 생성 완료) 값 신규 추가 
- QSheet 스케쥴 동작시, 사용한 QSet status 값 업데이트하도록 변경 

### 비고 (첨부자료)
테스트 완료했고 잘 만들어지는 것까지 확인했습니다. 
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/8aed037c-a7c2-49e5-a195-29e53dca8b00">

```sql 
select question_set_id,  count(*)
from question_sheet
group by question_set_id

12 개 * 81 명 = 972 
```
<img width="582" alt="image" src="https://github.com/user-attachments/assets/8029b18c-dff7-4b48-8881-f92329bf562c">
