### PR TITLE
[update] pick open time using QSet publishedAt

### DIFF
--- a/_endpoint_test/pick.http
+++ b/_endpoint_test/pick.http
@@ -29,4 +29,7 @@ Content-Type: application/json
 ### Variables
 @id=1
 
+### GET NEXT PICK TIME 
+GET {{host}}/pick/next-pick-time
+Authorization: {{authorization}}
 

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -43,7 +43,7 @@ interface QuestionService {
 
     fun getOperatingQuestionSet(): QuestionSet?
 
-    fun getNextOperatingQuestionSet(): QuestionSet?
+    fun getNextOperatingQuestionSet(status: Status = Status.UPCOMING): QuestionSet?
 
     fun getLatestPublishedQuestionSet(): QuestionSet?
 
@@ -130,9 +130,9 @@ class DefaultQuestionService(
     }
 
     // 발행 출격 준비 완료 QuestionSet
-    override fun getNextOperatingQuestionSet(): QuestionSet? {
-        return questionSetRepository.findFirstByStatusAndPublishedAtAfterOrderByPublishedAtAsc(Status.UPCOMING)?.toQuestionSet() ?: run {
-            log.error { "Published And Prepared for sortie QuestionSet Entity not found" }
+    override fun getNextOperatingQuestionSet(status: Status): QuestionSet? {
+        return questionSetRepository.findFirstByStatusAndPublishedAtAfterOrderByPublishedAtAsc(status)?.toQuestionSet() ?: run {
+            log.error { "next Operating QuestionSet status : [$status] Entity not found" }
             null
         }
     }

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
@@ -29,15 +29,6 @@ interface PickUseCase {
         val pageSize: Int,
     )
 
-    data class GetReceivedPick(
-        val pickId: PickId,
-        val questionId: QuestionId,
-        val questionContent: String,
-        val questionEmojiImageUrl: String,
-        val totalReceivedPickCount: Int,
-        val latestPickedAt: LocalDateTime,
-    )
-
     data class GetPagingPickCommand(
         val memberId: MemberId,
         val questionId: QuestionId,

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/PickUseCase.kt
@@ -2,6 +2,7 @@ package com.mashup.dojo.usecase
 
 import com.mashup.dojo.DojoException
 import com.mashup.dojo.DojoExceptionType
+import com.mashup.dojo.Status
 import com.mashup.dojo.domain.MemberId
 import com.mashup.dojo.domain.PickId
 import com.mashup.dojo.domain.PickOpenItem
@@ -14,7 +15,6 @@ import com.mashup.dojo.service.MemberService
 import com.mashup.dojo.service.NotificationService
 import com.mashup.dojo.service.PickService
 import com.mashup.dojo.service.QuestionService
-import com.mashup.dojo.usecase.PickUseCase.GetReceivedPick
 import com.mashup.dojo.usecase.PickUseCase.GetReceivedPickPagingCommand
 import com.mashup.dojo.usecase.PickUseCase.OpenPickCommand
 import com.mashup.dojo.usecase.PickUseCase.PickOpenInfo
@@ -169,10 +169,10 @@ class DefaultPickUseCase(
     }
 
     override fun getNextPickTime(): LocalDateTime {
-        return pickService.getNextPickTime()
-    }
+        val nextOperatingQuestionSet =
+            questionService.getNextOperatingQuestionSet(Status.READY)
+                ?: throw DojoException.of(DojoExceptionType.QUESTION_SET_NOT_READY)
 
-    companion object {
-        private val EMPTY_RECEIVED_PICK = emptyList<GetReceivedPick>()
+        return nextOperatingQuestionSet.publishedAt
     }
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- pick NextOpenTime 에 대해서 다음 발행 예정인 QSet publishTime 을 사용하도록 변경하였습니다. 

### 비고 (첨부자료)
