### PR TITLE
update : questionSheet 조회시 order sort

### DIFF
--- a/api/src/main/kotlin/com/mashup/dojo/dto/QuestionDto.kt
+++ b/api/src/main/kotlin/com/mashup/dojo/dto/QuestionDto.kt
@@ -65,7 +65,7 @@ data class QuestionSheetResponse(
     val resolverId: MemberId,
     @Schema(description = "질문 고유 id")
     val questionId: QuestionId,
-    @Schema(description = "질문지 묶음 중 해당 질문지의 순서")
+    @Schema(description = "질문지 묶음 중 해당 질문지의 순서. 1부터 시작(1based) ~ max : QuestionSheetsGetResponse.sheetTotalCount")
     val questionOrder: Int,
     @Schema(description = "질문 내용")
     val questionContent: String,

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -199,10 +199,11 @@ class DefaultQuestionUseCase(
 
                     val question = questionService.getQuestionById(qSheet.questionId) ?: throw DojoException.of(DojoExceptionType.QUESTION_NOT_EXIST)
                     val imageUrl = imageService.load(question.emojiImageId)?.url ?: throw DojoException.of(DojoExceptionType.NOT_EXIST, "image id ${question.emojiImageId} not exist")
-                    val questionOrder = questionIds.indexOf(qSheet.questionId)
+                    val questionOrder = questionIds.indexOf(qSheet.questionId) + 1 // 순서는 1based
 
                     qSheet.toQuestionSheetResult(questionOrder, question.content, question.category, imageUrl, candidateResults)
                 }
+                .sortedBy { it.questionOrder }
 
         return QuestionUseCase.GetQuestionSheetsResult(
             resolverId = memberId,


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [ ] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
- 질문지 조회시, questionOrder 순으로 응답이 안내려가고 있어 sorting 합니다
- 응답에서 questionOrder 를 1based 로 수정합니다. 
### 비고 (첨부자료)
