### PR TITLE
fix : 전체 대상에 대한 질문에 대해선 후보자 친구+비친구로 변경

### DIFF
--- a/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
+++ b/entity/src/main/kotlin/com/mashup/dojo/MemberRelationRepository.kt
@@ -56,7 +56,7 @@ interface MemberRelationQueryRepository {
         limit: Long,
     ): List<String>
 
-    fun findRandomOfAccompany(
+    fun findRandomOfAll(
         memberId: String,
         limit: Long,
     ): List<String>
@@ -142,7 +142,7 @@ class MemberRelationQueryRepositoryImpl(
             .fetch()
     }
 
-    override fun findRandomOfAccompany(
+    override fun findRandomOfAll(
         memberId: String,
         limit: Long,
     ): List<String> {
@@ -151,10 +151,7 @@ class MemberRelationQueryRepositoryImpl(
         return jpaQueryFactory
             .select(memberRelation.toId)
             .from(memberRelation)
-            .where(
-                memberRelation.fromId.eq(memberId),
-                memberRelation.relationType.eq(RelationType.ACCOMPANY)
-            )
+            .where(memberRelation.fromId.eq(memberId))
             .orderBy(Expressions.numberTemplate(Double::class.java, "function('RAND')").asc())
             .limit(8)
             .fetch()

--- a/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/MemberRelationService.kt
@@ -41,7 +41,7 @@ interface MemberRelationService {
 
     fun findCandidateOfFriend(memberId: MemberId): List<MemberId>
 
-    fun findCandidateOfAccompany(memberId: MemberId): List<MemberId>
+    fun findCandidateOfAll(memberId: MemberId): List<MemberId>
 
     fun findRelationByIds(
         fromId: MemberId,
@@ -123,8 +123,8 @@ class DefaultMemberRelationService(
         }
     }
 
-    override fun findCandidateOfAccompany(memberId: MemberId): List<MemberId> {
-        return memberRelationRepository.findRandomOfAccompany(
+    override fun findCandidateOfAll(memberId: MemberId): List<MemberId> {
+        return memberRelationRepository.findRandomOfAll(
             memberId = memberId.value,
             limit = defaultCandidateSize
         ).map {

--- a/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/service/QuestionService.kt
@@ -78,7 +78,7 @@ interface QuestionService {
         questionId: QuestionId,
         resolver: MemberId,
         candidatesOfFriend: List<MemberId>,
-        candidatesOfAccompany: List<MemberId>,
+        candidatesOfAll: List<MemberId>,
         questionType: QuestionType,
     ): QuestionSheet
 
@@ -252,7 +252,7 @@ class DefaultQuestionService(
         questionId: QuestionId,
         resolver: MemberId,
         candidatesOfFriend: List<MemberId>,
-        candidatesOfAccompany: List<MemberId>,
+        candidatesOfAll: List<MemberId>,
         questionType: QuestionType,
     ): QuestionSheet {
         /**
@@ -262,19 +262,15 @@ class DefaultQuestionService(
          * 질문의 타입에 따라 적절한 후보자 리스트를 사용
          */
 
-        if (candidatesOfFriend.size < defaultCandidateSize && candidatesOfAccompany.size < defaultCandidateSize) {
+        if (candidatesOfFriend.size < defaultCandidateSize && candidatesOfAll.size < defaultCandidateSize) {
             throw DojoException.of(DojoExceptionType.CANDIDATE_INVALID_SIZE)
         }
 
         val candidates =
             when (questionType) {
-                QuestionType.FRIEND ->
-                    // 친구 후보자의 크기가 기본 크기보다 작을 경우 비친구 후보자를 사용
-                    if (candidatesOfFriend.size < defaultCandidateSize) candidatesOfAccompany else candidatesOfFriend
-
-                QuestionType.ACCOMPANY ->
-                    // 비친구 후보자의 크기가 기본 크기보다 작을 경우 친구 후보자를 사용
-                    if (candidatesOfAccompany.size < defaultCandidateSize) candidatesOfFriend else candidatesOfAccompany
+                // 친구 후보자의 크기가 기본 크기보다 작을 경우 전체 후보자를 사용
+                QuestionType.FRIEND -> if (candidatesOfFriend.size < defaultCandidateSize) candidatesOfAll else candidatesOfFriend
+                QuestionType.ACCOMPANY -> candidatesOfAll
             }
 
         return QuestionSheet.create(

--- a/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
+++ b/service/src/main/kotlin/com/mashup/dojo/usecase/QuestionUseCase.kt
@@ -136,8 +136,8 @@ class DefaultQuestionUseCase(
                 val questionSheets =
                     questions.map { questionOrder ->
                         val candidatesOfFriend = memberRelationService.findCandidateOfFriend(member.id)
-                        val candidatesOfAccompany = memberRelationService.findCandidateOfAccompany(member.id)
-
+                        // all -> accompany + friend
+                        val candidatesOfAll = memberRelationService.findCandidateOfAll(member.id)
                         val questionType = questionOrder.type
 
                         // 질문의 타입에 따라 다른 후보자 리스트를 전달
@@ -147,7 +147,7 @@ class DefaultQuestionUseCase(
                             questionType = questionType,
                             resolver = member.id,
                             candidatesOfFriend = candidatesOfFriend,
-                            candidatesOfAccompany = candidatesOfAccompany
+                            candidatesOfAll = candidatesOfAll
                         )
                     }
                 questionSheets


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[add] pr template`
- [x] 🧹 불필요한 코드는 제거했나요?

### 작업 내용
지난 미팅 때 나온 비즈니스 로직 결함으로 질문 카테고리 중 전체에 해당하는 질문에는 후보자를 전체로 변경합니다. 
### 비고 (첨부자료)
